### PR TITLE
[libs] Fix SerialClass available() return value 

### DIFF
--- a/cores/common/arduino/libraries/api/Serial/Serial.cpp
+++ b/cores/common/arduino/libraries/api/Serial/Serial.cpp
@@ -24,7 +24,7 @@ void SerialClass::adrParse(uint8_t c) {
 #endif
 
 int SerialClass::available() {
-	return this->buf && this->buf->available();
+	return this->buf ? this->buf->available() : 0;
 }
 
 int SerialClass::peek() {


### PR DESCRIPTION
This PR changes the SerialClass::available() return value to 0 if no data is available on the referenced UART port. 
Issues:
#153
#155  