### PR TITLE
[beken-72xx] Allow connecting to specific BSSID if provided

### DIFF
--- a/cores/beken-72xx/arduino/libraries/WiFi/WiFi.cpp
+++ b/cores/beken-72xx/arduino/libraries/WiFi/WiFi.cpp
@@ -7,6 +7,7 @@ WiFiClass::WiFiClass() {
 
 	DATA->scanSem	  = xSemaphoreCreateBinary();
 	STA_CFG.dhcp_mode = DHCP_CLIENT;
+	STA_ADV_CFG.dhcp_mode = DHCP_CLIENT;
 }
 
 WiFiClass::~WiFiClass() {

--- a/cores/beken-72xx/arduino/libraries/WiFi/WiFi.cpp
+++ b/cores/beken-72xx/arduino/libraries/WiFi/WiFi.cpp
@@ -5,8 +5,8 @@
 WiFiClass::WiFiClass() {
 	data = (WiFiData *)calloc(1, sizeof(WiFiData));
 
-	DATA->scanSem	  = xSemaphoreCreateBinary();
-	STA_CFG.dhcp_mode = DHCP_CLIENT;
+	DATA->scanSem		  = xSemaphoreCreateBinary();
+	STA_CFG.dhcp_mode	  = DHCP_CLIENT;
 	STA_ADV_CFG.dhcp_mode = DHCP_CLIENT;
 }
 

--- a/cores/beken-72xx/arduino/libraries/WiFi/WiFiPrivate.h
+++ b/cores/beken-72xx/arduino/libraries/WiFi/WiFiPrivate.h
@@ -56,7 +56,7 @@ extern void wifiEventHandler(rw_evt_type event);
 #define IP_FMT "%u.%u.%u.%u"
 
 typedef struct {
-	network_InitTypeDef_st configSta;
+	network_InitTypeDef_adv_st configSta;
 	network_InitTypeDef_ap_st configAp;
 	unsigned long scannedAt;
 	SemaphoreHandle_t scanSem;
@@ -72,7 +72,7 @@ typedef struct {
 #define pDATA ((WiFiData *)pWiFi->data)
 #define cDATA ((WiFiData *)cls->data)
 
-#define STA_CFG		(DATA->configSta)
+#define STA_CFG	(DATA->configSta)
 #define AP_CFG		(DATA->configAp)
 #define IP_STATUS	(DATA->statusIp)
 #define LINK_STATUS (DATA->statusLink)

--- a/cores/beken-72xx/arduino/libraries/WiFi/WiFiPrivate.h
+++ b/cores/beken-72xx/arduino/libraries/WiFi/WiFiPrivate.h
@@ -56,7 +56,8 @@ extern void wifiEventHandler(rw_evt_type event);
 #define IP_FMT "%u.%u.%u.%u"
 
 typedef struct {
-	network_InitTypeDef_adv_st configSta;
+	network_InitTypeDef_st configSta;
+	network_InitTypeDef_adv_st configStaAdv;
 	network_InitTypeDef_ap_st configAp;
 	unsigned long scannedAt;
 	SemaphoreHandle_t scanSem;
@@ -73,6 +74,7 @@ typedef struct {
 #define cDATA ((WiFiData *)cls->data)
 
 #define STA_CFG	(DATA->configSta)
+#define STA_ADV_CFG	(DATA->configStaAdv)
 #define AP_CFG		(DATA->configAp)
 #define IP_STATUS	(DATA->statusIp)
 #define LINK_STATUS (DATA->statusLink)

--- a/cores/beken-72xx/arduino/libraries/WiFi/WiFiPrivate.h
+++ b/cores/beken-72xx/arduino/libraries/WiFi/WiFiPrivate.h
@@ -73,8 +73,8 @@ typedef struct {
 #define pDATA ((WiFiData *)pWiFi->data)
 #define cDATA ((WiFiData *)cls->data)
 
-#define STA_CFG	(DATA->configSta)
-#define STA_ADV_CFG	(DATA->configStaAdv)
+#define STA_CFG		(DATA->configSta)
+#define STA_ADV_CFG (DATA->configStaAdv)
 #define AP_CFG		(DATA->configAp)
 #define IP_STATUS	(DATA->statusIp)
 #define LINK_STATUS (DATA->statusLink)

--- a/cores/beken-72xx/arduino/libraries/WiFi/WiFiSTA.cpp
+++ b/cores/beken-72xx/arduino/libraries/WiFi/WiFiSTA.cpp
@@ -25,9 +25,6 @@ WiFiClass::begin(const char *ssid, const char *passphrase, int32_t channel, cons
 		}
 		STA_ADV_CFG.ap_info.channel = channel;
 		STA_ADV_CFG.wifi_retry_interval = 100;
-
-		// Unsure why, but this gets unset in advanced config if set during config(), but standard config survives
-		STA_ADV_CFG.dhcp_mode = STA_CFG.dhcp_mode;
 	} else {
 		strcpy(STA_CFG.wifi_ssid, ssid);
 		memset(STA_CFG.wifi_bssid, 0x00, 6);

--- a/cores/beken-72xx/arduino/libraries/WiFi/WiFiSTA.cpp
+++ b/cores/beken-72xx/arduino/libraries/WiFi/WiFiSTA.cpp
@@ -15,7 +15,6 @@ WiFiClass::begin(const char *ssid, const char *passphrase, int32_t channel, cons
 
 	if (bssid) {
 		strcpy(STA_ADV_CFG.ap_info.ssid, ssid);
-		memcpy(STA_ADV_CFG.ap_info.bssid, bssid, 6);
 		if (passphrase) {
 			strcpy(STA_ADV_CFG.key, passphrase);
 			STA_ADV_CFG.key_len = strlen(passphrase);
@@ -27,7 +26,6 @@ WiFiClass::begin(const char *ssid, const char *passphrase, int32_t channel, cons
 		STA_ADV_CFG.wifi_retry_interval = 100;
 	} else {
 		strcpy(STA_CFG.wifi_ssid, ssid);
-		memset(STA_CFG.wifi_bssid, 0x00, 6);
 		if (passphrase) {
 			strcpy(STA_CFG.wifi_key, passphrase);
 		} else {

--- a/cores/beken-72xx/arduino/libraries/WiFi/WiFiSTA.cpp
+++ b/cores/beken-72xx/arduino/libraries/WiFi/WiFiSTA.cpp
@@ -25,6 +25,9 @@ WiFiClass::begin(const char *ssid, const char *passphrase, int32_t channel, cons
 		}
 		STA_ADV_CFG.ap_info.channel = channel;
 		STA_ADV_CFG.wifi_retry_interval = 100;
+
+		// Unsure why, but this gets unset in advanced config if set during config(), but standard config survives
+		STA_ADV_CFG.dhcp_mode = STA_CFG.dhcp_mode;
 	} else {
 		strcpy(STA_CFG.wifi_ssid, ssid);
 		memset(STA_CFG.wifi_bssid, 0x00, 6);
@@ -95,8 +98,6 @@ bool WiFiClass::reconnect(const uint8_t *bssid) {
 
 	if (bssid) {
 		LT_IM(WIFI, "Connecting to " MACSTR, MAC2STR(bssid));
-		// Unsure why, but this gets unset in advanced config if set during config(), but standard config survives
-		STA_ADV_CFG.dhcp_mode = STA_CFG.dhcp_mode;
 	} else {
 		LT_IM(WIFI, "Connecting to %s", STA_CFG.wifi_ssid);
 	}

--- a/cores/beken-72xx/arduino/libraries/WiFi/WiFiSTA.cpp
+++ b/cores/beken-72xx/arduino/libraries/WiFi/WiFiSTA.cpp
@@ -57,14 +57,14 @@ bool WiFiClass::config(IPAddress localIP, IPAddress gateway, IPAddress subnet, I
 			sprintf(STA_CFG.dns_server_ip_addr, IP_FMT, dns1[0], dns1[1], dns1[2], dns1[3]);
 			sprintf(STA_ADV_CFG.dns_server_ip_addr, IP_FMT, dns1[0], dns1[1], dns1[2], dns1[3]);
 		} else {
-			STA_CFG.dns_server_ip_addr[0] = '\0';
+			STA_CFG.dns_server_ip_addr[0]     = '\0';
 			STA_ADV_CFG.dns_server_ip_addr[0] = '\0';
 		}
 	} else {
-		STA_CFG.local_ip_addr[0]      = '\0';
-		STA_CFG.net_mask[0]           = '\0';
-		STA_CFG.gateway_ip_addr[0]    = '\0';
-		STA_CFG.dns_server_ip_addr[0] = '\0';
+		STA_CFG.local_ip_addr[0]          = '\0';
+		STA_CFG.net_mask[0]               = '\0';
+		STA_CFG.gateway_ip_addr[0]        = '\0';
+		STA_CFG.dns_server_ip_addr[0]     = '\0';
 		STA_ADV_CFG.local_ip_addr[0]      = '\0';
 		STA_ADV_CFG.net_mask[0]           = '\0';
 		STA_ADV_CFG.gateway_ip_addr[0]    = '\0';
@@ -116,7 +116,6 @@ bool WiFiClass::reconnect(const uint8_t *bssid) {
 	} else {
 		bk_wlan_start_sta(&STA_CFG);
 	}
-	
 	__wrap_bk_printf_enable();
 
 	LT_DM(WIFI, "Start OK");

--- a/cores/beken-72xx/arduino/libraries/WiFi/WiFiSTA.cpp
+++ b/cores/beken-72xx/arduino/libraries/WiFi/WiFiSTA.cpp
@@ -101,6 +101,11 @@ bool WiFiClass::reconnect(const uint8_t *bssid) {
 
 	LT_DM(WIFI, "Data = %p", DATA->configSta);
 
+	if (bssid)
+		memcpy(STA_ADV_CFG.ap_info.bssid, bssid, 6);
+	else
+		memset(STA_CFG.wifi_bssid, 0x00, 6);
+
 	if (STA_CFG.dhcp_mode == DHCP_DISABLE) {
 		LT_DM(WIFI, "Static IP: %s / %s / %s", STA_CFG.local_ip_addr, STA_CFG.net_mask, STA_CFG.gateway_ip_addr);
 		LT_DM(WIFI, "Static DNS: %s", STA_CFG.dns_server_ip_addr);

--- a/cores/beken-72xx/arduino/libraries/WiFi/WiFiSTA.cpp
+++ b/cores/beken-72xx/arduino/libraries/WiFi/WiFiSTA.cpp
@@ -96,6 +96,7 @@ bool WiFiClass::reconnect(const uint8_t *bssid) {
 	} else {
 		LT_IM(WIFI, "Connecting to %s", STA_CFG.wifi_ssid);
 		memset(STA_CFG.wifi_bssid, 0x00, 6);
+		STA_CFG.wifi_mode = BK_STATION;
 	}
 
 	LT_DM(WIFI, "Data = %p", DATA->configSta);

--- a/cores/beken-72xx/arduino/libraries/WiFi/WiFiSTA.cpp
+++ b/cores/beken-72xx/arduino/libraries/WiFi/WiFiSTA.cpp
@@ -20,10 +20,10 @@ WiFiClass::begin(const char *ssid, const char *passphrase, int32_t channel, cons
 			strcpy(STA_ADV_CFG.key, passphrase);
 			STA_ADV_CFG.key_len = strlen(passphrase);
 		} else {
-			STA_ADV_CFG.key[0] = '\0';
+			STA_ADV_CFG.key[0]	= '\0';
 			STA_ADV_CFG.key_len = 0;
 		}
-		STA_ADV_CFG.ap_info.channel = channel;
+		STA_ADV_CFG.ap_info.channel		= channel;
 		STA_ADV_CFG.wifi_retry_interval = 100;
 	} else {
 		strcpy(STA_CFG.wifi_ssid, ssid);
@@ -34,7 +34,7 @@ WiFiClass::begin(const char *ssid, const char *passphrase, int32_t channel, cons
 			STA_CFG.wifi_key[0] = '\0';
 		}
 		STA_CFG.wifi_retry_interval = 100;
-		STA_CFG.wifi_mode = BK_STATION;
+		STA_CFG.wifi_mode			= BK_STATION;
 	}
 
 	if (reconnect(bssid))
@@ -44,7 +44,7 @@ WiFiClass::begin(const char *ssid, const char *passphrase, int32_t channel, cons
 }
 
 bool WiFiClass::config(IPAddress localIP, IPAddress gateway, IPAddress subnet, IPAddress dns1, IPAddress dns2) {
-	STA_CFG.dhcp_mode = localIP ? DHCP_DISABLE : DHCP_CLIENT;
+	STA_CFG.dhcp_mode	  = localIP ? DHCP_DISABLE : DHCP_CLIENT;
 	STA_ADV_CFG.dhcp_mode = localIP ? DHCP_DISABLE : DHCP_CLIENT;
 	if (localIP) {
 		sprintf(STA_CFG.local_ip_addr, IP_FMT, localIP[0], localIP[1], localIP[2], localIP[3]);
@@ -57,17 +57,17 @@ bool WiFiClass::config(IPAddress localIP, IPAddress gateway, IPAddress subnet, I
 			sprintf(STA_CFG.dns_server_ip_addr, IP_FMT, dns1[0], dns1[1], dns1[2], dns1[3]);
 			sprintf(STA_ADV_CFG.dns_server_ip_addr, IP_FMT, dns1[0], dns1[1], dns1[2], dns1[3]);
 		} else {
-			STA_CFG.dns_server_ip_addr[0]     = '\0';
+			STA_CFG.dns_server_ip_addr[0]	  = '\0';
 			STA_ADV_CFG.dns_server_ip_addr[0] = '\0';
 		}
 	} else {
-		STA_CFG.local_ip_addr[0]          = '\0';
-		STA_CFG.net_mask[0]               = '\0';
-		STA_CFG.gateway_ip_addr[0]        = '\0';
-		STA_CFG.dns_server_ip_addr[0]     = '\0';
-		STA_ADV_CFG.local_ip_addr[0]      = '\0';
-		STA_ADV_CFG.net_mask[0]           = '\0';
-		STA_ADV_CFG.gateway_ip_addr[0]    = '\0';
+		STA_CFG.local_ip_addr[0]		  = '\0';
+		STA_CFG.net_mask[0]				  = '\0';
+		STA_CFG.gateway_ip_addr[0]		  = '\0';
+		STA_CFG.dns_server_ip_addr[0]	  = '\0';
+		STA_ADV_CFG.local_ip_addr[0]	  = '\0';
+		STA_ADV_CFG.net_mask[0]			  = '\0';
+		STA_ADV_CFG.gateway_ip_addr[0]	  = '\0';
 		STA_ADV_CFG.dns_server_ip_addr[0] = '\0';
 	}
 


### PR DESCRIPTION
bk72xx - Allow connecting to a specific BSSID via `bk_wlan_start_sta_adv` which is bssid-aware, instead of `bk_wlan_start_sta` which is not, and falling back to `bk_wlan_start_sta` when one is not present (fast_connect).