### PR TITLE
Fixed stopping PWM

### DIFF
--- a/cores/beken-72xx/arduino/src/wiring.c
+++ b/cores/beken-72xx/arduino/src/wiring.c
@@ -109,8 +109,10 @@ void pinRemoveMode(PinInfo *pin, uint32_t mask) {
 	}
 	if ((mask & PIN_PWM) && (pin->enabled & PIN_PWM)) {
 		data->pwm->cfg.bits.en = PWM_DISABLE;
+		uint32_t channel_in_32bit = data->pwm->channel;
 		__wrap_bk_printf_disable();
-		sddev_control(PWM_DEV_NAME, CMD_PWM_DEINIT_PARAM, data->pwm);
+		sddev_control(PWM_DEV_NAME, CMD_PWM_INIT_LEVL_SET_LOW, &channel_in_32bit);
+		sddev_control(PWM_DEV_NAME, CMD_PWM_UNIT_DISABLE, &channel_in_32bit);
 		__wrap_bk_printf_enable();
 		pinDisable(pin, PIN_PWM);
 	}

--- a/cores/beken-72xx/arduino/src/wiring_analog.c
+++ b/cores/beken-72xx/arduino/src/wiring_analog.c
@@ -91,6 +91,7 @@ void analogWrite(pin_size_t pinNumber, int value) {
 	uint32_t frequency = 26 * _analogWritePeriod - 1;
 	uint32_t dutyCycle = percent * frequency;
 	pwm.channel		   = gpioToPwm(pin->gpio);
+	uint32_t channel_in_32bit = pwm.channel;
 #if CFG_SOC_NAME != SOC_BK7231N
 	pwm.duty_cycle = dutyCycle;
 #else
@@ -110,13 +111,14 @@ void analogWrite(pin_size_t pinNumber, int value) {
 			pwm.p_Int_Handler	= NULL;
 			__wrap_bk_printf_disable();
 			sddev_control(PWM_DEV_NAME, CMD_PWM_INIT_PARAM, &pwm);
-			sddev_control(PWM_DEV_NAME, CMD_PWM_INIT_LEVL_SET_HIGH, &pwm.channel);
-			sddev_control(PWM_DEV_NAME, CMD_PWM_UNIT_ENABLE, &pwm.channel);
+			sddev_control(PWM_DEV_NAME, CMD_PWM_INIT_LEVL_SET_HIGH, &channel_in_32bit);
+			sddev_control(PWM_DEV_NAME, CMD_PWM_UNIT_ENABLE, &channel_in_32bit);
 			__wrap_bk_printf_enable();
 			// pass global PWM object pointer
 			data->pwm = &pwm;
 			pinEnable(pin, PIN_PWM);
 		} else {
+			sddev_control(PWM_DEV_NAME, CMD_PWM_INIT_LEVL_SET_HIGH, &channel_in_32bit);
 			// update duty cycle
 			sddev_control(PWM_DEV_NAME, CMD_PWM_SET_DUTY_CYCLE, &pwm);
 		}


### PR DESCRIPTION
If you look into the beken sdk, it seems that one of the actions taken on CMD_PWM_DEINIT_PARAM is actually setting the pin as gpio input. I believe this was unexpected in LT and was screwing the state after. So... maybe it's better not to call it at all, and instead use CMD_PWM_UNIT_DISABLE? Although I don't know what side effects this might have.
This seems to fix #200 , at least on my Woox ambient lamp.

Also, CMD_PWM_INIT_LEVL_SET_LOW seems to be called in example sdk code, when duty cycle is being set to 0. I guess there's no hurt doing this too :)

Also, some sddev_control commands expect channel number as parameter, but they expect a 32bit value, while in LT you used 8bit. To be on the safe side, maybe it's better to fix this.

