### PR TITLE
[docs] Add more UPK key descriptions

### DIFF
--- a/docs/resources/tuya-pin-config.md
+++ b/docs/resources/tuya-pin-config.md
@@ -111,6 +111,12 @@ Key(s)                                      | Meaning                           
 `pirsense_pin` + `pirsense_lv`              | PIR sensitivity (PWM) + Active Level  |
 `pirrange`                                  |                                       |
 `pirwarn`                                   |                                       |
+**Ambient light sensor**                    |                                       |
+`day`                                       | Value to compare against ADC readout  | ADC value range (0-3300)
+`dusk`                                      | Value to compare against ADC readout  | ADC value range (0-3300)
+`evenfall`                                  | Value to compare against ADC readout  | ADC value range (0-3300)
+`evening`                                   | Value to compare against ADC readout  | ADC value range (0-3300)
+`night`                                     | Value to compare against ADC readout  | ADC value range (0-3300)
 **Key-controlled**                          |                                       |
 `key_pin` + `key_lv`                        | Key Pin + Active Level                |
 `kXpin_pin` + `kXpin_lv`                    |                                       |
@@ -165,7 +171,6 @@ Key(s)                                      | Meaning                           
 `ctrl_pin`                                  |                                       |
 `customcode`                                |                                       |
 `cyc_dpid`                                  |                                       |
-`day`                                       |                                       |
 `dctrl_select`                              |                                       |
 `dimmod`                                    |                                       |
 `dimt`                                      |                                       |
@@ -174,9 +179,6 @@ Key(s)                                      | Meaning                           
 `door1_magt_pin`                            |                                       |
 `door_alarm_st1`                            |                                       |
 `door_mag1`                                 |                                       |
-`dusk`                                      |                                       |
-`evenfall`                                  |                                       |
-`evening`                                   |                                       |
 `ffc_select`                                |                                       |
 `inch_dp`                                   |                                       |
 `indep_cfgbt`                               |                                       |
@@ -197,7 +199,6 @@ Key(s)                                      | Meaning                           
 `netnc`                                     |                                       |
 `nety_led`                                  |                                       |
 `netyc`                                     |                                       |
-`night`                                     |                                       |
 `nightbrig`                                 |                                       |
 `nightcct`                                  |                                       |
 `nightled`                                  |                                       |

--- a/docs/resources/tuya-pin-config.md
+++ b/docs/resources/tuya-pin-config.md
@@ -7,7 +7,7 @@ Originally posted [by @blakadder](https://discord.com/channels/96786352151160837
 Key(s)                                      | Meaning                               | Possible values
 --------------------------------------------|---------------------------------------|---------------------------------------------------------
 `crc`                                       |                                       |
-`module`                                    |                                       |
+`module`                                    |Actual hw board used                   | `CB3S` / `WB3S`, maybe others
 `category`                                  |Device type encoded on a set of digits | 0502 - cw light<br>0505 - rgbcw light
 `Jsonver`<br>`jv`                           |                                       |
 **Common**                                  |                                       |
@@ -93,12 +93,12 @@ Key(s)                                      | Meaning                           
 `wgmod`, `swgmod`, `scgmod`                 |                                       |
 **PIR**                                     |                                       |
 `pirmod`                                    |                                       |
-`pirfreq`                                   |                                       |
-`pirlduty`                                  |                                       |
-`pirmduty`                                  |                                       |
-`pirhduty`                                  |                                       |
-`pirin_pin` + `pirin_lv`                    |                                       |
-`pirsense_pin` + `pirsense_lv`              |                                       |
+`pirfreq`                                   | PWM Operating Frequency (Hz) for PIR  | 1000
+`pirlduty`                                  |                                       | 100
+`pirmduty`                                  |                                       | 50
+`pirhduty`                                  |                                       | 0
+`pirin_pin` + `pirin_lv`                    | GPIO pin used to report motion + Active Level|
+`pirsense_pin` + `pirsense_lv`              | PIR sensitivity pwm pin + Active Level|
 `pirrange`                                  |                                       |
 `pirwarn`                                   |                                       |
 **Key-controlled**                          |                                       |

--- a/docs/resources/tuya-pin-config.md
+++ b/docs/resources/tuya-pin-config.md
@@ -4,11 +4,15 @@ Device configuration (`user_param_key`) can be extracted to JSON, using bk7231to
 
 Originally posted [by @blakadder](https://discord.com/channels/967863521511608370/983843871320580096/1059286760074530947) on Discord channel #resources, modified by me to include more keys and values.
 
+Also see:
+
+- [UPK2ESPHome](https://upk.libretiny.eu/)
+
 Key(s)                                      | Meaning                               | Possible values
---------------------------------------------|---------------------------------------|---------------------------------------------------------
+--------------------------------------------|---------------------------------------|---------------------------------------------------------------------------------------------------------------------------
 `crc`                                       |                                       |
-`module`                                    |Actual hw board used                   | `CB3S` / `WB3S`, maybe others
-`category`                                  |Device type encoded on a set of digits | 0502 - cw light<br>0505 - rgbcw light
+`module`                                    | Actual hw board used                  | `CB3S` / `WB3S`, maybe others
+`category`                                  | Device type encoded                   | 0502 - cw light<br>0505 - rgbcw light
 `Jsonver`<br>`jv`                           |                                       |
 **Common**                                  |                                       |
 `netled_pin`<br>`netled1_pin`<br>`wfst_pin` | Status LED for WiFi                   |
@@ -37,10 +41,10 @@ Key(s)                                      | Meaning                           
 `gmkr`, `gmkg`, `gmkb`                      |                                       |
 `gmwr`, `gmwg`, `gmwb`                      |                                       |
 `hsvstep`                                   |                                       |
-`rgbt`                                      |Used in prod.tests, not relevant       |
-`rstbr`                                     |Pairing related - not relevant         | 10-100
-`rstcor`                                    |Pairing related - not relevant         | `c`/`r`
-`rsttemp`                                   |Pairing related - not relevant         | 0-100
+`rgbt`                                      | Used in prod.tests, not relevant      |
+`rstbr`                                     | Pairing related - not relevant        | 10-100
+`rstcor`                                    | Pairing related - not relevant        | `c`/`r`
+`rsttemp`                                   | Pairing related - not relevant        | 0-100
 **PWM Lights**                              |                                       |
 `r_pin` + `r_lv`                            | Red Channel Pin + Active Level        |
 `g_pin` + `g_lv`                            | Green Channel Pin + Active Level      |
@@ -97,8 +101,8 @@ Key(s)                                      | Meaning                           
 `pirlduty`                                  |                                       | 100
 `pirmduty`                                  |                                       | 50
 `pirhduty`                                  |                                       | 0
-`pirin_pin` + `pirin_lv`                    | GPIO pin used to report motion + Active Level|
-`pirsense_pin` + `pirsense_lv`              | PIR sensitivity pwm pin + Active Level|
+`pirin_pin` + `pirin_lv`                    | Motion reporting GPIO + Active Level  |
+`pirsense_pin` + `pirsense_lv`              | PIR sensitivity (PWM) + Active Level  |
 `pirrange`                                  |                                       |
 `pirwarn`                                   |                                       |
 **Key-controlled**                          |                                       |
@@ -127,7 +131,7 @@ Key(s)                                      | Meaning                           
 `bleonoff`                                  |                                       |
 `blindt`                                    |                                       |
 `buzzer`                                    |                                       |
-`cagt`                                      |Used in prod.tests, not relevant       | N/A
+`cagt`                                      | Used in prod.tests, not relevant      | N/A
 `cctseg`                                    |                                       |
 `cd_flag2`                                  |                                       |
 `cdsval`                                    |                                       |
@@ -138,7 +142,7 @@ Key(s)                                      | Meaning                           
 `ch_num`                                    |                                       |
 `clean_t`                                   |                                       |
 `cntdown1`                                  |                                       |
-`colorpfun`                                 |The power limit of the mix of colors   |0 - no limits<br>1 - limits specified
+`colorpfun`                                 | The power limit of the mix of colors  | 0 - no limits<br>1 - limits specified
 `ctrl_lv`                                   |                                       |
 `ctrl_pin`                                  |                                       |
 `customcode`                                |                                       |
@@ -149,7 +153,7 @@ Key(s)                                      | Meaning                           
 `dimt`                                      |                                       |
 `dimval`                                    |                                       |
 `dmod`                                      | Light driver                          | 0 - PWM<br>1 - SM16726B<br>2 - SM2135E
-`defcolor`                                  | Default light color                   | 
+`defcolor`                                  | Default light color                   |
 `door1_magt_lv`                             |                                       |
 `door1_magt_pin`                            |                                       |
 `door_alarm_st1`                            |                                       |
@@ -181,7 +185,7 @@ Key(s)                                      | Meaning                           
 `nightbrig`                                 |                                       |
 `nightcct`                                  |                                       |
 `nightled`                                  |                                       |
-`notdisturb`                                |Do not disturb (DND) mode              | 0 - DND disabled<br>1 - DND enabled
+`notdisturb`                                | Do not disturb (DND) mode             | 0 - DND disabled<br>1 - DND enabled
 `on_off_cnt`                                |                                       |
 `onoff1`                                    |                                       |
 `onoff_clear_t`                             |                                       |
@@ -189,23 +193,23 @@ Key(s)                                      | Meaning                           
 `onoff_rst_m`                               |                                       |
 `onoff_rst_type`                            |                                       |
 `onoff_type`                                |                                       |
-`onoffmode`                                 |On/off gradient                        | 0 - Gradient is provided when the light is turned on/off.<br>1 - Gradient is not provided when the light is turned on/off.
+`onoffmode`                                 | On/off gradient                       | 0 - Gradient is provided when the light is turned on/off.<br>1 - Gradient is not provided when the light is turned on/off.
 `onofftime`                                 |                                       |
 `owm`                                       |                                       |
-`pairt`                                     |Pairing related - not relevant         | 6-600
-`pmemory`                                   |Power-off memory                       | 0 - power-off memory disabled<br>1: power-off memory enabled
+`pairt`                                     | Pairing related - not relevant        | 6-600
+`pmemory`                                   | Power-off memory                      | 0 - power-off memory disabled<br>1: power-off memory enabled
 `preheatt`                                  |                                       |
-`prodagain`                                 |Used in prod.tests, not relevant       | 0-1
+`prodagain`                                 | Used in prod.tests, not relevant      | 0-1
 `rand_dpid`                                 |                                       |
-`remdmode`                                  |Pairing related - not relevant         | 0-1
+`remdmode`                                  | Pairing related - not relevant        | 0-1
 `remote_add_dp`                             |                                       |
 `remote_list_dp`                            |                                       |
 `remote_select`                             |                                       |
 `resistor`                                  |                                       |
 `reuse_led_m`                               |                                       |
 `rsthold`                                   |                                       |
-`rstmode`                                   |Pairing related - not relevant         |
-`rstnum`                                    |Pairing related - not relevant         |
+`rstmode`                                   | Pairing related - not relevant        |
+`rstnum`                                    | Pairing related - not relevant        |
 `scenespct`                                 |                                       |
 `series_ctrl`                               |                                       |
 `sfunc`                                     |                                       |
@@ -224,5 +228,5 @@ Key(s)                                      | Meaning                           
 `voice_ctrl1`                               |                                       |
 `voice_ctrl_set1`                           |                                       |
 `whiteseg`                                  |                                       |
-`wt`                                        |Used in prod.tests, not relevant       | N/A
+`wt`                                        | Used in prod.tests, not relevant      | N/A
 `zero_select`                               |                                       |

--- a/docs/resources/tuya-pin-config.md
+++ b/docs/resources/tuya-pin-config.md
@@ -37,7 +37,7 @@ Key(s)                                      | Meaning                           
 `defcolor`                                  | Default Color                         | `c` / `r`
 `defbright`                                 | Default Brightness                    | 0%-100%
 `deftemp`                                   | Default Color Temperature             | 0-100 when defcolor is cool white
-`cwmaxp`                                    | Cold-Warm Max Power                   | 0%-100%
+`cwmaxp`                                    | Cold-Warm Max Power                   | 100-200 with a pitch of 10
 `brightmin`, `brightmax`                    | Min/Max Brightness                    | 0%-100%
 `colormin`, `colormax`                      | RGB Min/Max Brightness                | 0%-100%
 `cwmin`, `cwmax`                            | Cold-Warm Min/Max Brightness          | 0%-100%

--- a/docs/resources/tuya-pin-config.md
+++ b/docs/resources/tuya-pin-config.md
@@ -2,18 +2,21 @@
 
 Device configuration (`user_param_key`) can be extracted to JSON, using bk7231tools from a full firmware dump.
 
-Originally posted [by @blakadder](https://discord.com/channels/967863521511608370/983843871320580096/1059286760074530947) on Discord channel #resources, modified by me to include more keys and values.
-
 Also see:
 
 - [UPK2ESPHome](https://upk.libretiny.eu/)
 
+Sources:
+
+- [`tuya_demo_light_pwm`](https://github.com/tuya/tuya-iotos-embeded-sdk-wifi-ble-bk7231n/blob/master/apps/tuya_demo_light_pwm/include/common/device_config_load.h) for *Lights/bulbs*
+- Original post [by @blakadder](https://discord.com/channels/967863521511608370/983843871320580096/1059286760074530947) on Discord channel #resources
+
 Key(s)                                      | Meaning                               | Possible values
---------------------------------------------|---------------------------------------|---------------------------------------------------------------------------------------------------------------------------
-`crc`                                       |                                       |
-`module`                                    | Actual hw board used                  | `CB3S` / `WB3S`, maybe others
-`category`                                  | Device type encoded                   | 0502 - cw light<br>0505 - rgbcw light
-`Jsonver`<br>`jv`                           |                                       |
+--------------------------------------------|---------------------------------------|---------------------------------------------------------------------------------------
+`crc`                                       | UPK data checksum                     |
+`module`                                    | Tuya module used                      | `CB3S` / `WB3S` / `CBU`, etc.
+`category`                                  | Device type as a number               | 0502 - CW light<br>0505 - RGBCW light
+`Jsonver`<br>`jv`                           | "JSON" version                        |
 **Common**                                  |                                       |
 `netled_pin`<br>`netled1_pin`<br>`wfst_pin` | Status LED for WiFi                   |
 `netled_lv`<br>`netled1_lv`<br>`wfst_lv`    | Status LED Active Level               | 0 - Active low<br>1 - Active high
@@ -24,27 +27,30 @@ Key(s)                                      | Meaning                           
 `iicsda`                                    | I²C SDA Pin                           |
 `net_trig`                                  |                                       |
 `net_type`                                  |                                       |
-`wfcfg`                                     | Pairing related - not relevant        | `spcl` / `spcl_auto` / `prod`
 `wfct`                                      |                                       |
 **Lights/bulbs**                            |                                       |
 `cmod`                                      | Color Mode                            | `rgbcw` / `rgb` / `cw` / `c` / `rgbc`
+`dmod`                                      | Light driver type                     | 0 - PWM<br>1 - SM16726B<br>2 - SM2135E<br>3 - SM2135EH<br>4 - SM2135EJ<br>5 - BP1658CJ
 `cwtype`                                    | Color temperature driver              | 0 - cool and warm white (CW)<br>1 - correlated color temperature (CCT)
-`brightmin`, `brightmax`                    | Min/Max Brightness                    | 0%-100%
-`cwmin`, `cwmax`                            | Cold-Warm Min/Max Brightness          | 0%-100%
-`cwmaxp`                                    | Cold-Warm Max Power                   | 0%-100%
-`colormin`, `colormax`                      | RGB Min/Max Brightness                | 0%-100%
-`colormaxp`                                 | RGB Max Power                         | 0%-100%
-`brightstep`<br>`bristep`                   | Brightness Step                       |
-`defbright`                                 | Default Brightness                    | 0%-100%
+`onoffmode`                                 | On/off gradient enabled               | 0 / 1
+`pmemory`                                   | Power-off memory enabled              | 0 / 1
 `defcolor`                                  | Default Color                         | `c` / `r`
+`defbright`                                 | Default Brightness                    | 0%-100%
 `deftemp`                                   | Default Color Temperature             | 0-100 when defcolor is cool white
-`gmkr`, `gmkg`, `gmkb`                      |                                       |
-`gmwr`, `gmwg`, `gmwb`                      |                                       |
+`cwmaxp`                                    | Cold-Warm Max Power                   | 0%-100%
+`brightmin`, `brightmax`                    | Min/Max Brightness                    | 0%-100%
+`colormin`, `colormax`                      | RGB Min/Max Brightness                | 0%-100%
+`cwmin`, `cwmax`                            | Cold-Warm Min/Max Brightness          | 0%-100%
+`colormaxp`                                 | RGB Max Power                         | 0%-100%
+`colorpfun`                                 | Color mixing power limit enabled      | 0 / 1
+`brightstep`<br>`bristep`                   | Brightness Step                       |
 `hsvstep`                                   |                                       |
 `rgbt`                                      | Used in prod.tests, not relevant      |
-`rstbr`                                     | Pairing related - not relevant        | 10-100
-`rstcor`                                    | Pairing related - not relevant        | `c`/`r`
-`rsttemp`                                   | Pairing related - not relevant        | 0-100
+`title20`                                   | "title20/T20" supported               | 0 / 1
+**Gamma correction**                        |                                       |
+`gmr`, `gmg`, `gmb`                         |                                       |
+`gmkr`, `gmkg`, `gmkb`                      |                                       |
+`gmwr`, `gmwg`, `gmwb`                      |                                       |
 **PWM Lights**                              |                                       |
 `r_pin` + `r_lv`                            | Red Channel Pin + Active Level        |
 `g_pin` + `g_lv`                            | Green Channel Pin + Active Level      |
@@ -76,7 +82,7 @@ Key(s)                                      | Meaning                           
 `rl_drvtime`                                |                                       |
 `total_bt_pin` + `total_bt_lv`              |                                       |
 **Power monitoring**                        |                                       |
-`ele_fun_en`                                | Power Monitoring Enabled              | 1
+`ele_fun_en`                                | Power Monitoring Enabled              | 0 / 1
 `chip_type`                                 | Power Monitoring Chip Type            | 0 - BL0937<br>1 - HLW8012<br>2 - HLW8032<br>4 - BL0942
 `ele_pin`                                   | CF Pin                                |
 `vi_pin`                                    | CF1 Pin                               |
@@ -88,7 +94,7 @@ Key(s)                                      | Meaning                           
 `vol_def`                                   | Socket operating voltage              | 0 - 220V<br>1 - 110V
 `work_voltage`                              | Socket operating voltage              |
 **Infrared**                                |                                       |
-`irfunc`                                    | IR Function                           | 0, 1
+`irfunc`                                    | IR Function enabled                   | 0 / 1
 `infre`                                     | IR Transmitter Pin                    |
 `infrr`<br>`ir`                             | IR Receiver Pin                       |
 `irkXfun` + `irkXval`                       | IR Key X Function + Value             | X in 1..30
@@ -113,9 +119,23 @@ Key(s)                                      | Meaning                           
 `keyccfg1`, `keyccfg2`                      |                                       |
 `keyfunc`, `keyglobefunc`                   |                                       |
 `keylt`, `keynumber`                        |                                       |
+**Pairing-related**                         |                                       |
+`wfcfg`                                     | Wi-Fi pairing config                  | `spcl` / `spcl_auto` / `prod` / `old` / `low`
+`remdmode`                                  | "light reset pairing mode"            | 0 / 1
+`rstnum`                                    | On/off cycles to reset                |
+`rstcor`                                    | Light color while connecting          | `c` / `r`
+`rstbr`                                     | Light brightness while connecting     | 10-100
+`rsttemp`                                   | Light temperature while connecting    | 0-100
+`remdtime`                                  | Pairing mode timeout                  | seconds
+`wfptime`                                   | Light pairing time                    | minutes
+`cagt`                                      | Used in prod.tests, not relevant      | N/A
+`prodagain`                                 | Used in prod.tests, not relevant      | 0 / 1
+`rstmode`                                   | Pairing related - not relevant        |
+`pairt`                                     | Pairing related - not relevant        | 6-600
+`wt`                                        | Used in prod.tests, not relevant      | N/A
 **Other**                                   |                                       |
 `buzzer_pwm`                                | Buzzer working PWM frequency          |
-`ismusic`                                   |                                       | 0, 1
+`ismusic`                                   |                                       | 0 / 1
 `ledX_pin` + `ledX_lv`                      | LED X Pin + Active Level              |
 `led_pin` + `led_lv`                        | LED Pin + Active Level                |
 **Unknown**                                 |                                       |
@@ -131,7 +151,6 @@ Key(s)                                      | Meaning                           
 `bleonoff`                                  |                                       |
 `blindt`                                    |                                       |
 `buzzer`                                    |                                       |
-`cagt`                                      | Used in prod.tests, not relevant      | N/A
 `cctseg`                                    |                                       |
 `cd_flag2`                                  |                                       |
 `cdsval`                                    |                                       |
@@ -142,7 +161,6 @@ Key(s)                                      | Meaning                           
 `ch_num`                                    |                                       |
 `clean_t`                                   |                                       |
 `cntdown1`                                  |                                       |
-`colorpfun`                                 | The power limit of the mix of colors  | 0 - no limits<br>1 - limits specified
 `ctrl_lv`                                   |                                       |
 `ctrl_pin`                                  |                                       |
 `customcode`                                |                                       |
@@ -152,8 +170,6 @@ Key(s)                                      | Meaning                           
 `dimmod`                                    |                                       |
 `dimt`                                      |                                       |
 `dimval`                                    |                                       |
-`dmod`                                      | Light driver                          | 0 - PWM<br>1 - SM16726B<br>2 - SM2135E
-`defcolor`                                  | Default light color                   |
 `door1_magt_lv`                             |                                       |
 `door1_magt_pin`                            |                                       |
 `door_alarm_st1`                            |                                       |
@@ -185,7 +201,7 @@ Key(s)                                      | Meaning                           
 `nightbrig`                                 |                                       |
 `nightcct`                                  |                                       |
 `nightled`                                  |                                       |
-`notdisturb`                                | Do not disturb (DND) mode             | 0 - DND disabled<br>1 - DND enabled
+`notdisturb`                                | Do not disturb (DND) mode enabled     | 0 / 1
 `on_off_cnt`                                |                                       |
 `onoff1`                                    |                                       |
 `onoff_clear_t`                             |                                       |
@@ -193,23 +209,16 @@ Key(s)                                      | Meaning                           
 `onoff_rst_m`                               |                                       |
 `onoff_rst_type`                            |                                       |
 `onoff_type`                                |                                       |
-`onoffmode`                                 | On/off gradient                       | 0 - Gradient is provided when the light is turned on/off.<br>1 - Gradient is not provided when the light is turned on/off.
 `onofftime`                                 |                                       |
 `owm`                                       |                                       |
-`pairt`                                     | Pairing related - not relevant        | 6-600
-`pmemory`                                   | Power-off memory                      | 0 - power-off memory disabled<br>1: power-off memory enabled
 `preheatt`                                  |                                       |
-`prodagain`                                 | Used in prod.tests, not relevant      | 0-1
 `rand_dpid`                                 |                                       |
-`remdmode`                                  | Pairing related - not relevant        | 0-1
 `remote_add_dp`                             |                                       |
 `remote_list_dp`                            |                                       |
 `remote_select`                             |                                       |
 `resistor`                                  |                                       |
 `reuse_led_m`                               |                                       |
 `rsthold`                                   |                                       |
-`rstmode`                                   | Pairing related - not relevant        |
-`rstnum`                                    | Pairing related - not relevant        |
 `scenespct`                                 |                                       |
 `series_ctrl`                               |                                       |
 `sfunc`                                     |                                       |
@@ -219,7 +228,6 @@ Key(s)                                      | Meaning                           
 `switch1`                                   |                                       |
 `tempmix`                                   |                                       |
 `tempstep`                                  |                                       |
-`title20`                                   |                                       |
 `total_stat`                                |                                       |
 `tracetime1`                                |                                       |
 `trigdelay`                                 |                                       |
@@ -228,5 +236,4 @@ Key(s)                                      | Meaning                           
 `voice_ctrl1`                               |                                       |
 `voice_ctrl_set1`                           |                                       |
 `whiteseg`                                  |                                       |
-`wt`                                        | Used in prod.tests, not relevant      | N/A
 `zero_select`                               |                                       |

--- a/docs/resources/tuya-pin-config.md
+++ b/docs/resources/tuya-pin-config.md
@@ -8,7 +8,7 @@ Key(s)                                      | Meaning                           
 --------------------------------------------|---------------------------------------|---------------------------------------------------------
 `crc`                                       |                                       |
 `module`                                    |                                       |
-`category`                                  |                                       |
+`category`                                  |Device type encoded on a set of digits | 0502 - cw light<br>0505 - rgbcw light
 `Jsonver`<br>`jv`                           |                                       |
 **Common**                                  |                                       |
 `netled_pin`<br>`netled1_pin`<br>`wfst_pin` | Status LED for WiFi                   |
@@ -20,11 +20,11 @@ Key(s)                                      | Meaning                           
 `iicsda`                                    | I²C SDA Pin                           |
 `net_trig`                                  |                                       |
 `net_type`                                  |                                       |
-`wfcfg`                                     |                                       | `spcl` / `spcl_auto` / `prod`
+`wfcfg`                                     | Pairing related - not relevant        | `spcl` / `spcl_auto` / `prod`
 `wfct`                                      |                                       |
 **Lights/bulbs**                            |                                       |
 `cmod`                                      | Color Mode                            | `rgbcw` / `rgb` / `cw` / `c` / `rgbc`
-`cwtype`                                    |                                       |
+`cwtype`                                    | Color temperature driver              | 0 - cool and warm white (CW)<br>1 - correlated color temperature (CCT)
 `brightmin`, `brightmax`                    | Min/Max Brightness                    | 0%-100%
 `cwmin`, `cwmax`                            | Cold-Warm Min/Max Brightness          | 0%-100%
 `cwmaxp`                                    | Cold-Warm Max Power                   | 0%-100%
@@ -33,14 +33,14 @@ Key(s)                                      | Meaning                           
 `brightstep`<br>`bristep`                   | Brightness Step                       |
 `defbright`                                 | Default Brightness                    | 0%-100%
 `defcolor`                                  | Default Color                         | `c` / `r`
-`deftemp`                                   | Default Color Temperature             |
+`deftemp`                                   | Default Color Temperature             | 0-100 when defcolor is cool white
 `gmkr`, `gmkg`, `gmkb`                      |                                       |
 `gmwr`, `gmwg`, `gmwb`                      |                                       |
 `hsvstep`                                   |                                       |
-`rgbt`                                      |                                       |
-`rstbr`                                     |                                       |
-`rstcor`                                    |                                       | `c`/`r`
-`rsttemp`                                   |                                       |
+`rgbt`                                      |Used in prod.tests, not relevant       |
+`rstbr`                                     |Pairing related - not relevant         | 10-100
+`rstcor`                                    |Pairing related - not relevant         | `c`/`r`
+`rsttemp`                                   |Pairing related - not relevant         | 0-100
 **PWM Lights**                              |                                       |
 `r_pin` + `r_lv`                            | Red Channel Pin + Active Level        |
 `g_pin` + `g_lv`                            | Green Channel Pin + Active Level      |
@@ -52,8 +52,8 @@ Key(s)                                      | Meaning                           
 `dccur`<br>`ehccur`<br>`cjccur`             | Cold White Current                    |
 `dwcur`<br>`ehwcur`<br>`cjwcur`             | Warm White Current                    |
 `drgbcur`                                   | RGB Current                           |
-`campere`                                   |                                       |
-`wampere`                                   |                                       |
+`campere`                                   | Max current of SM2135 colored output  | 10-45 with a pitch of 5 and defaults to 20
+`wampere`                                   | Max current of SM2135 white output    | 10-80 with a pitch of 5 and defaults to 30
 `iicr`                                      | Red Channel Number                    | 0-5
 `iicg`                                      | Green Channel Number                  | 0-5
 `iicb`                                      | Blue Channel Number                   | 0-5
@@ -127,7 +127,7 @@ Key(s)                                      | Meaning                           
 `bleonoff`                                  |                                       |
 `blindt`                                    |                                       |
 `buzzer`                                    |                                       |
-`cagt`                                      |                                       |
+`cagt`                                      |Used in prod.tests, not relevant       | N/A
 `cctseg`                                    |                                       |
 `cd_flag2`                                  |                                       |
 `cdsval`                                    |                                       |
@@ -138,7 +138,7 @@ Key(s)                                      | Meaning                           
 `ch_num`                                    |                                       |
 `clean_t`                                   |                                       |
 `cntdown1`                                  |                                       |
-`colorpfun`                                 |                                       |
+`colorpfun`                                 |The power limit of the mix of colors   |0 - no limits<br>1 - limits specified
 `ctrl_lv`                                   |                                       |
 `ctrl_pin`                                  |                                       |
 `customcode`                                |                                       |
@@ -148,7 +148,8 @@ Key(s)                                      | Meaning                           
 `dimmod`                                    |                                       |
 `dimt`                                      |                                       |
 `dimval`                                    |                                       |
-`dmod`                                      |                                       |
+`dmod`                                      | Light driver                          | 0 - PWM<br>1 - SM16726B<br>2 - SM2135E
+`defcolor`                                  | Default light color                   | 
 `door1_magt_lv`                             |                                       |
 `door1_magt_pin`                            |                                       |
 `door_alarm_st1`                            |                                       |
@@ -180,7 +181,7 @@ Key(s)                                      | Meaning                           
 `nightbrig`                                 |                                       |
 `nightcct`                                  |                                       |
 `nightled`                                  |                                       |
-`notdisturb`                                |                                       |
+`notdisturb`                                |Do not disturb (DND) mode              | 0 - DND disabled<br>1 - DND enabled
 `on_off_cnt`                                |                                       |
 `onoff1`                                    |                                       |
 `onoff_clear_t`                             |                                       |
@@ -188,23 +189,23 @@ Key(s)                                      | Meaning                           
 `onoff_rst_m`                               |                                       |
 `onoff_rst_type`                            |                                       |
 `onoff_type`                                |                                       |
-`onoffmode`                                 |                                       |
+`onoffmode`                                 |On/off gradient                        | 0 - Gradient is provided when the light is turned on/off.<br>1 - Gradient is not provided when the light is turned on/off.
 `onofftime`                                 |                                       |
 `owm`                                       |                                       |
-`pairt`                                     |                                       |
-`pmemory`                                   |                                       |
+`pairt`                                     |Pairing related - not relevant         | 6-600
+`pmemory`                                   |Power-off memory                       | 0 - power-off memory disabled<br>1: power-off memory enabled
 `preheatt`                                  |                                       |
-`prodagain`                                 |                                       |
+`prodagain`                                 |Used in prod.tests, not relevant       | 0-1
 `rand_dpid`                                 |                                       |
-`remdmode`                                  |                                       |
+`remdmode`                                  |Pairing related - not relevant         | 0-1
 `remote_add_dp`                             |                                       |
 `remote_list_dp`                            |                                       |
 `remote_select`                             |                                       |
 `resistor`                                  |                                       |
 `reuse_led_m`                               |                                       |
 `rsthold`                                   |                                       |
-`rstmode`                                   |                                       |
-`rstnum`                                    |                                       |
+`rstmode`                                   |Pairing related - not relevant         |
+`rstnum`                                    |Pairing related - not relevant         |
 `scenespct`                                 |                                       |
 `series_ctrl`                               |                                       |
 `sfunc`                                     |                                       |
@@ -223,5 +224,5 @@ Key(s)                                      | Meaning                           
 `voice_ctrl1`                               |                                       |
 `voice_ctrl_set1`                           |                                       |
 `whiteseg`                                  |                                       |
-`wt`                                        |                                       |
+`wt`                                        |Used in prod.tests, not relevant       | N/A
 `zero_select`                               |                                       |

--- a/docs/resources/tuya-pin-config.md
+++ b/docs/resources/tuya-pin-config.md
@@ -30,7 +30,7 @@ Key(s)                                      | Meaning                           
 `wfct`                                      |                                       |
 **Lights/bulbs**                            |                                       |
 `cmod`                                      | Color Mode                            | `rgbcw` / `rgb` / `cw` / `c` / `rgbc`
-`dmod`                                      | Light driver type                     | 0 - PWM<br>1 - SM16726B<br>2 - SM2135E<br>3 - SM2135EH<br>4 - SM2135EJ<br>5 - BP1658CJ
+`dmod`                                      | Light driver type                     | 0 - PWM<br>1 - SM16726B<br>2 - SM2135E<br>3 - SM2135EH<br>4 - SM2135EJ<br>5 - BP1658CJ<br>6 - BP5758D<br>7 - SM2235/2335
 `cwtype`                                    | Color temperature driver              | 0 - cool and warm white (CW)<br>1 - correlated color temperature (CCT)
 `onoffmode`                                 | On/off gradient enabled               | 0 / 1
 `pmemory`                                   | Power-off memory enabled              | 0 / 1


### PR DESCRIPTION
Based on description from tuya website (links provided in #218) I have filled in some of the missing information. The description was for bluetooth devices, but the keys I described seem to be more or less universal.