### PR TITLE
[beken-72xx] Improve ddev ADC support

### DIFF
--- a/cores/beken-72xx/arduino/src/wiring_analog.c
+++ b/cores/beken-72xx/arduino/src/wiring_analog.c
@@ -66,13 +66,21 @@ uint16_t analogReadVoltage(pin_size_t pinNumber) {
 	adc.pData		   = adcData;
 	adc.data_buff_size = 1;
 	handle			   = ddev_open(SARADC_DEV_NAME, &status, (uint32_t)&adc);
-	if (status)
+	if (handle == -1) {
 		return 0;
+	}
+
+	if (status != SARADC_SUCCESS) {
+		ddev_close(handle);
+		return 0;
+	}
+
 	// wait for data
 	while (!adc.has_data || adc.current_sample_data_cnt < 1) {
 		delay(1);
 	}
-	ddev_control(handle, SARADC_CMD_RUN_OR_STOP_ADC, (void *)false);
+	uint8_t run_stop = 0; // stop
+	ddev_control(handle, SARADC_CMD_RUN_OR_STOP_ADC, &run_stop);
 	ddev_close(handle);
 	return adcData[0];
 }


### PR DESCRIPTION
One of the users reported issue esphome/issues#5201 with ADC on BK7231N, so I took a look at the code and found something that could be related. I don't own any N device with ADC, so cannot really test this. But I have checked my T devices with this fix and the ADC still works there.