### PR TITLE
[docs] Update docker compose image name

### DIFF
--- a/docs/projects/esphome.md
+++ b/docs/projects/esphome.md
@@ -34,7 +34,7 @@ If your board isn't listed, use one of the **Generic** boards, depending on the 
 		services:
 		  esphome:
 		    container_name: esphome-libretiny
-		    image: docker pull ghcr.io/libretiny-eu/libretiny-esphome-docker:latest
+		    image: ghcr.io/libretiny-eu/libretiny-esphome-docker:latest
 		    volumes:
 		      - ./configs:/config:rw # (1)!
 		      - /etc/localtime:/etc/localtime:ro


### PR DESCRIPTION
The docs about using docker  compose for libre tuya had an error. When setting what image to use in compose you dont have to put docker pull, just the image you are going to use