### PR TITLE
[beken-72xx] Free list returned by wlan_sta_scan_result()

### DIFF
--- a/cores/beken-72xx/arduino/libraries/WiFi/WiFiScan.cpp
+++ b/cores/beken-72xx/arduino/libraries/WiFi/WiFiScan.cpp
@@ -16,6 +16,8 @@ static void scanHandler(void *ctx, uint8_t param) {
 	}
 
 	ScanResult_adv result;
+	result.ApNum  = 0;
+	result.ApList = NULL;
 	if (wlan_sta_scan_result(&result)) {
 		LT_EM(WIFI, "Failed to get scan result");
 		goto end;
@@ -46,6 +48,9 @@ end:
 		// running == false means it was discarded (timeout)
 		scan->running = false;
 		xSemaphoreGive(cDATA->scanSem);
+	}
+	if (result.ApList) {
+		free(result.ApList);
 	}
 	LT_HEAP_I();
 	return;

--- a/cores/beken-72xx/arduino/libraries/WiFi/WiFiScan.cpp
+++ b/cores/beken-72xx/arduino/libraries/WiFi/WiFiScan.cpp
@@ -24,12 +24,13 @@ static void scanHandler(void *ctx, uint8_t param) {
 	}
 	LT_IM(WIFI, "Found %d APs", result.ApNum);
 
-	if (!cls->scanAlloc(result.ApNum)) {
+	auto apNum = cls->scanAlloc(result.ApNum);
+	if (0 == apNum) {
 		LT_WM(WIFI, "scan->ap alloc failed");
 		goto end;
 	}
 
-	for (uint8_t i = 0; i < result.ApNum; i++) {
+	for (uint8_t i = 0; i < apNum; i++) {
 		scan->ap[i].ssid	= strdup(result.ApList[i].ssid);
 		scan->ap[i].auth	= securityTypeToAuthMode(result.ApList[i].security);
 		scan->ap[i].rssi	= result.ApList[i].ApPower;

--- a/cores/beken-72xx/arduino/libraries/WiFi/WiFiScan.cpp
+++ b/cores/beken-72xx/arduino/libraries/WiFi/WiFiScan.cpp
@@ -24,8 +24,7 @@ static void scanHandler(void *ctx, uint8_t param) {
 	}
 	LT_IM(WIFI, "Found %d APs", result.ApNum);
 
-	cls->scanAlloc(result.ApNum);
-	if (!scan->ap) {
+	if (!cls->scanAlloc(result.ApNum)) {
 		LT_WM(WIFI, "scan->ap alloc failed");
 		goto end;
 	}

--- a/cores/beken-72xx/arduino/libraries/WiFi/WiFiScan.cpp
+++ b/cores/beken-72xx/arduino/libraries/WiFi/WiFiScan.cpp
@@ -15,6 +15,7 @@ static void scanHandler(void *ctx, uint8_t param) {
 		return;
 	}
 
+	uint8_t apNum = 0;
 	ScanResult_adv result;
 	result.ApNum  = 0;
 	result.ApList = NULL;
@@ -24,10 +25,14 @@ static void scanHandler(void *ctx, uint8_t param) {
 	}
 	LT_IM(WIFI, "Found %d APs", result.ApNum);
 
-	auto apNum = cls->scanAlloc(result.ApNum);
+	apNum = cls->scanAlloc(result.ApNum);
 	if (0 == apNum) {
 		LT_WM(WIFI, "scan->ap alloc failed");
 		goto end;
+	}
+
+	if (apNum < result.ApNum) {
+		LT_WM(WIFI, "alloc failed, only %d APs will be copied");
 	}
 
 	for (uint8_t i = 0; i < apNum; i++) {

--- a/cores/common/arduino/libraries/api/WiFi/WiFi.h
+++ b/cores/common/arduino/libraries/api/WiFi/WiFi.h
@@ -163,7 +163,7 @@ class WiFiClass {
 	);
 
 	int16_t scanComplete();
-	bool scanAlloc(uint8_t count);
+	uint8_t scanAlloc(uint8_t count);
 	void scanInit();
 	void scanDelete();
 

--- a/cores/common/arduino/libraries/api/WiFi/WiFi.h
+++ b/cores/common/arduino/libraries/api/WiFi/WiFi.h
@@ -163,7 +163,7 @@ class WiFiClass {
 	);
 
 	int16_t scanComplete();
-	uint8_t scanAlloc(uint8_t count);
+	bool scanAlloc(uint8_t count);
 	void scanInit();
 	void scanDelete();
 

--- a/cores/common/arduino/libraries/api/WiFi/WiFiScan.cpp
+++ b/cores/common/arduino/libraries/api/WiFi/WiFiScan.cpp
@@ -38,14 +38,20 @@ void WiFiClass::scanDelete() {
 	scan = NULL;
 }
 
-uint8_t WiFiClass::scanAlloc(uint8_t count) {
-	uint8_t last = scan->count;
-	scan->count	 = count;
-	scan->ap	 = (WiFiScanAP *)realloc(scan->ap, count * sizeof(WiFiScanAP));
-	if (!scan->ap)
-		return 255;
-	memset(scan->ap + last, 0, sizeof(WiFiScanAP));
-	return last;
+bool WiFiClass::scanAlloc(uint8_t count) {
+	if ((!scan->ap) || (count > scan->count)) {
+		auto newMem = (WiFiScanAP *)realloc(scan->ap, count * sizeof(WiFiScanAP));
+		if (!newMem) {
+			return false;
+		}
+		scan->ap = newMem;
+	}
+	if (!scan->ap) {
+		return false;
+	}
+	scan->count = count;
+	memset(scan->ap + count, 0, sizeof(WiFiScanAP));
+	return true;
 }
 
 String WiFiClass::SSID(uint8_t networkItem) {

--- a/cores/common/arduino/libraries/api/WiFi/WiFiScan.cpp
+++ b/cores/common/arduino/libraries/api/WiFi/WiFiScan.cpp
@@ -38,23 +38,24 @@ void WiFiClass::scanDelete() {
 	scan = NULL;
 }
 
-bool WiFiClass::scanAlloc(uint8_t count) {
+uint8_t WiFiClass::scanAlloc(uint8_t count) {
 	if ((!scan->ap) || (count > scan->count)) {
 		auto newMem = (WiFiScanAP *)realloc(scan->ap, count * sizeof(WiFiScanAP));
 		if (!newMem) {
-			return false;
+			return scan->count;
 		}
 		scan->ap = newMem;
 	}
 	if (!scan->ap) {
-		return false;
+		scan->count = 0;
+		return 0;
 	}
 	if (count > scan->count) {
 		// clear only new entries
 		memset(scan->ap + scan->count, 0, sizeof(WiFiScanAP) * (count - scan->count));
 	}
 	scan->count = count;
-	return true;
+	return count;
 }
 
 String WiFiClass::SSID(uint8_t networkItem) {

--- a/cores/common/arduino/libraries/api/WiFi/WiFiScan.cpp
+++ b/cores/common/arduino/libraries/api/WiFi/WiFiScan.cpp
@@ -49,8 +49,11 @@ bool WiFiClass::scanAlloc(uint8_t count) {
 	if (!scan->ap) {
 		return false;
 	}
+	if (count > scan->count) {
+		// clear only new entries
+		memset(scan->ap + scan->count, 0, sizeof(WiFiScanAP) * (count - scan->count));
+	}
 	scan->count = count;
-	memset(scan->ap + count, 0, sizeof(WiFiScanAP));
 	return true;
 }
 

--- a/cores/realtek-amb/arduino/libraries/WiFi/WiFiScan.cpp
+++ b/cores/realtek-amb/arduino/libraries/WiFi/WiFiScan.cpp
@@ -20,7 +20,10 @@ static rtw_result_t scanHandler(rtw_scan_handler_result_t *result) {
 	if (!net->SSID.len)
 		return RTW_SUCCESS;
 
-	uint8_t last = cls->scanAlloc(scan->count + 1);
+	uint8_t last = scan->count + 1;
+	if (!cls->scanAlloc(last)) {
+		return RTW_ERROR;
+	}
 
 	scan->ap[last].ssid	   = strdup((char *)net->SSID.val);
 	scan->ap[last].auth	   = securityTypeToAuthMode(net->security);

--- a/cores/realtek-amb/arduino/libraries/WiFi/WiFiScan.cpp
+++ b/cores/realtek-amb/arduino/libraries/WiFi/WiFiScan.cpp
@@ -21,8 +21,8 @@ static rtw_result_t scanHandler(rtw_scan_handler_result_t *result) {
 		return RTW_SUCCESS;
 
 	uint8_t last = scan->count + 1;
-	if (!cls->scanAlloc(last)) {
-		return RTW_ERROR;
+	if (cls->scanAlloc(last) < last) {
+		return RTW_SUCCESS;
 	}
 
 	scan->ap[last].ssid	   = strdup((char *)net->SSID.val);


### PR DESCRIPTION
This method might return a dynamically allocated buffer which should be freed by the caller (the example code does it). Not doing this results in memory leaks.