### PR TITLE
[libs] Fix MD5 calculation during OTA update

### DIFF
--- a/cores/common/arduino/libraries/common/Update/Update.cpp
+++ b/cores/common/arduino/libraries/common/Update/Update.cpp
@@ -149,8 +149,8 @@ size_t UpdateClass::write(const uint8_t *data, size_t len) {
 	if (!this->ctx)
 		return 0;
 
-	size_t written = lt_ota_write(ctx, data, len);
 	MD5Update(this->md5Ctx, data, len);
+	size_t written = lt_ota_write(ctx, data, len);
 	if (written != len)
 		this->cleanup(/* clearError= */ false);
 	return written;


### PR DESCRIPTION
When the MCU is started with OTA1 image and you try to update the firmware, the OTA process fails:

```
[D][ota:320]: OTA in progress: 48.8%
[D][ota:320]: OTA in progress: 65.1%
[D][ota:320]: OTA in progress: 81.5%
E [  57890.676] OTA: Error: MD5 Check Failed
E [  57890.680] OTA: - written: 1380864 of 1380864
E [  57890.688] OTA: - buf: size=2199023255552, left=1153652920625948496
E [  57890.691] OTA: - ctx: seq=4294967295, part=(null)
E [  57890.699] OTA: - buf: seq=2696/2697, addr=689920, len=252
[W][ota:336]: Error ending OTA!, error_code: 132
```

Turns out that `lt_ota_write()` modifies the data ("binpatch" to update memory addresses for OTA2) and therefore MD5Update has to be called _before_ writing the data.