### PR TITLE
Update Readme & improve md layout

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -3,46 +3,59 @@
 Using LibreTiny is simple, just like every other PlatformIO development platform.
 
 1. [Install PlatformIO](https://platformio.org/platformio-ide)
-2. `platformio platform install -f https://github.com/libretiny-eu/libretiny`
+2. `pio pkg install --platform https://github.com/libretiny-eu/libretiny.git`
 
 !!! tip
-	See the [Cloudcutter video guide](https://www.youtube.com/watch?v=sSj8f-HCHQ0) for a complete tutorial on flashing with [Cloudcutter](https://github.com/tuya-cloudcutter/tuya-cloudcutter) and installing [LibreTiny-ESPHome](../projects/esphome.md). **Includes Home Assistant Add-On setup.**
+    See the [Cloudcutter video guide](https://www.youtube.com/watch?v=sSj8f-HCHQ0) for a complete tutorial on flashing with [Cloudcutter](https://github.com/tuya-cloudcutter/tuya-cloudcutter) and installing [LibreTiny-ESPHome](../projects/esphome.md). **Includes Home Assistant Add-On setup.**
+
+    More information on Cloudcutter can be found in the [Tuya Cloudcutter GitHub repository](https://github.com/tuya-cloudcutter/tuya-cloudcutter).
 
 ## Board selection
 
-- Go to [Boards & CPU list](../status/supported.md).
-- Find the board your device has (usually, the model number is written on the silkscreen).
-	- If your board isn't available yet, use one of the "Generic" boards that matches the CPU you have.
-- Click on the board name. From the documentation page, note the board code.
-- Use this code to create a PlatformIO project.
+1. Navigate to the [supported boards & CPUs](../status/supported.md) list.
+2. Find the board your device has (usually, the model number is written on the silkscreen).  
+  *If your board isn't available yet, use one of the "Generic" boards that matches the CPU you your board has.*
+3. Click on the board name. A new page opens with information about the selected board name.
+4. Scroll down to the "Usage" section of the page, and copy the configuration section that is relevant to your use case.
 
 ## Run community projects
 
-LibreTiny was developed with popular community projects in mind. Currently, unofficial [ESPHome port](../projects/esphome.md) is available ([the PR](https://github.com/esphome/esphome/pull/3509) will hopefully be merged into upstream at some point).
+LibreTiny was developed with popular community projects in mind.  
+There is an official [ESPHome port](../projects/esphome.md) available and integrated into the ESPHome project. No extra downloads or code compilations are needed to use ESPHome with LibreTiny-supported platforms.
 
 ## Develop your own project
 
-If you're developing your own embedded software, and want it to run on LibreTiny-supported chips, create a project.
+Developing your own embedded software that runs on LibreTiny-supported platforms.
 
-- use PlatformIO IDE (PIO Home -> Open -> New Project)
-- run `pio project init` in your desired project directory
+To get started with LibreTiny on your chosen platform, create a new project using your preferred method.
 
-Next, read one of the [flashing guides](../flashing/SUMMARY.md) to run your project!
+There's a few ways to create a new PlatformIO Project. For example:
 
-### LT configuration
+- using the PlatformIO IDE graphical interface (PIO Home -> Open -> New Project)
+- by running the `pio project init` command in your desired project directory  
+  *See the [PlatformIO Core (CLI) documentation] for information on `pio project init` and other command line usage.*
 
-LibreTiny has a few configuration options that change its behavior or features. Refer to [LT configuration](../dev/config.md) for details.
+Next, read one of the [flashing guides](../flashing/SUMMARY.md) to upload and run your project!
+
+### Config options (platformio.ini)
+
+LibreTiny has a few configuration options that allow you to change its behavior or features. These can be defined, specified or changed in the platformio.ini configuration file for your project.
+
+Refer to the LibreTiny [Configuration](../dev/config.md) manual for details.
 
 ### GPIO usage - important change
 
 !!! important
-	Since v1.0.0, GPIOs are no longer meant to be referenced by `D#` numbers.
+    As of LibreTiny release v1.0.0, references to GPIO pins using their `D#` numbers has been **deprecated** and should **no longer be used** in new projects.
 
-	If your program is using Arduino I/O functions, refer to the [Migration guide](../dev/migration_v1.0.0.md) to modify your program accordingly.
+    If your program is using Arduino I/O functions, please refer to the [migration guide](../dev/migration_v1.0.0.md) on how to modify your code accordingly.
 
 ### Examples
 
 {%
-	include-markdown "../../examples/SUMMARY.md"
-   start="# Examples\n"
+    include-markdown "../../examples/SUMMARY.md"
+    start="# Examples\n"
 %}
+
+<!-- These are reference URL's, which can be used to shorten inline hyperlinks to just their contextual title or text. -->
+[PlatformIO Core (CLI) documentation]: https://docs.platformio.org/en/stable/core/quickstart.html#setting-up-the-project


### PR DESCRIPTION
Made some improvements to the markdown text markup, as well as updated some text to reflect the current state of the project.

- ESPHome now supports LibreTiny natively
- Added extra PIO docs references
- Reworded some sections slightly, to accomodate proper grammar
- PIO deprecated the `platformio platform install` command, replaced this with the official recommendation/replacement
- Replaced hard tabs with space characters. These break things less often, and are strongly preferred.

## Tips for others:

- A line break without creating a new paragraph can be accomplished by ending your line with two whitespace characters. You can see this being used in some of the unordered lists.
- Use 4 space characters instead of tabs. Tabs have a tendency to display or behave inconsistently. This difference is already very visible between the GitHub web editor and Visual Studio Code.
- Use the Prettier or Markdown All-In-One plugins for VS Code when writing Markdown. It helps you stay in line with the markdown writing guidelines. 

## Remarks:

The file lacks a trailing space character, which is required by the Markdown spec. This space character seems to get removed whenever something is committed through the GitHub web editor. I can't add it without spinning up a clone of the repo, which is beyond what I have time for at this very moment. 