### PR TITLE
[beken-72xx] Fix duration rollover in deep sleep

### DIFF
--- a/cores/beken-72xx/base/api/lt_sleep.c
+++ b/cores/beken-72xx/base/api/lt_sleep.c
@@ -19,14 +19,13 @@ void lt_deep_sleep_unset_gpio(uint32_t gpio_index_map) {
 	deep_sleep_param.gpio_index_map &= (~gpio_index_map);
 }
 
-void lt_deep_sleep_config_timer(uint32_t sleep_duration) {
+void lt_deep_sleep_config_timer(uint32_t sleep_duration_ms) {
 	deep_sleep_param.wake_up_way |= PS_DEEP_WAKEUP_RTC;
-	uint64_t duration_math = 32768 * sleep_duration;
-	if (duration_math / 1000 > 0xFFFFFFFF) {
-		// Sleep forever
-		deep_sleep_param.sleep_time = 0xFFFFFFFF;
+	uint64_t sleep_ticks = 32.768 * sleep_duration_ms;
+	if (sleep_ticks >= 0xFFFFFFFF) {
+		deep_sleep_param.sleep_time = 0xFFFFFFFE;
 	} else {
-		deep_sleep_param.sleep_time = (duration_math / 1000) & 0xFFFFFFFF;
+		deep_sleep_param.sleep_time = sleep_ticks & 0xFFFFFFFF;
 	}
 }
 


### PR DESCRIPTION
per https://github.com/libretiny-eu/libretiny/issues/230

Tested on several BK7231N devices with ESPHome 2024.1.0-dev.