### PR TITLE
[realtek-ambz] Fix crash after WiFi scan

### DIFF
--- a/cores/realtek-amb/arduino/libraries/WiFi/WiFiScan.cpp
+++ b/cores/realtek-amb/arduino/libraries/WiFi/WiFiScan.cpp
@@ -24,6 +24,7 @@ static rtw_result_t scanHandler(rtw_scan_handler_result_t *result) {
 	if (cls->scanAlloc(last) < last) {
 		return RTW_SUCCESS;
 	}
+	last--;
 
 	scan->ap[last].ssid	   = strdup((char *)net->SSID.val);
 	scan->ap[last].auth	   = securityTypeToAuthMode(net->security);


### PR DESCRIPTION
```
[C][wifi:038]: Setting up WiFi...
[C][wifi:051]: Starting WiFi...
[C][wifi:052]:   Local MAC: 80:A0:36:A7:F7:1F
interface 0 is initialized
                          interface 1 is initialized

Initializing WIFI ...
WIFI initialized
                [D][wifi:459]: Starting scan...
RTL8195A[HAL]: Hard Fault Error!!!!
RTL8195A[HAL]: R0 = 0x1b9
```

As explained by @kuba2k2: "It seems that scanAlloc() returns the amount of allocated items, then the Realtek code tries to assign to the last item. The index in [] is wrong though, it tries to assign to one item past the last one."

Fixes #257
