### PR TITLE
[libs] Fix mDNS string memory corruption, print error on record add failure

### DIFF
--- a/cores/common/arduino/libraries/common/mDNS/LwIPmDNS.cpp
+++ b/cores/common/arduino/libraries/common/mDNS/LwIPmDNS.cpp
@@ -181,18 +181,17 @@ bool mDNS::addServiceImpl(const char *name, const char *service, uint8_t proto, 
 }
 
 bool mDNS::addServiceTxtImpl(const char *service, uint8_t proto, const char *item) {
-	int8_t index = -1;
-	for (uint8_t i = 0; i < services.size(); i++) {
+	uint8_t i;
+	for (i = 0; i < services.size(); i++) {
 		// find a matching service
 		if (strcmp(services[i], service) == 0 && protos[i] == proto) {
-			index = i;
 			break;
 		}
 	}
-	if (index == -1)
+	if (i == services.size())
 		return false;
 
-	records[index].push_back(strdup(item));
+	records[i].push_back(strdup(item));
 	return true;
 }
 

--- a/cores/common/arduino/libraries/common/mDNS/LwIPmDNS.cpp
+++ b/cores/common/arduino/libraries/common/mDNS/LwIPmDNS.cpp
@@ -32,186 +32,199 @@ NETIF_DECLARE_EXT_CALLBACK(netif_callback)
 #endif
 
 static inline void freeAllocatedStrings(const std::vector<char *> &strings) {
-  for (auto &str : strings) {
-    free(str);
-  }
+	for (auto &str : strings) {
+		free(str);
+	}
 }
 
 mDNS::mDNS() {}
 
-mDNS::~mDNS() { cleanup(); }
+mDNS::~mDNS() {
+	cleanup();
+}
 
 void mDNS::cleanup() {
-  freeAllocatedStrings(services_name);
-  services_name.clear();
-  freeAllocatedStrings(services);
-  services.clear();
-  for (auto &record : records) {
-    freeAllocatedStrings(record);
-  }
-  records.clear();
+	freeAllocatedStrings(services_name);
+	services_name.clear();
+	freeAllocatedStrings(services);
+	services.clear();
+	for (auto &record : records) {
+		freeAllocatedStrings(record);
+	}
+	records.clear();
 
-  free((void *)hostName);
-  hostName = NULL;
+	free((void *)hostName);
+	hostName = NULL;
 
-  free((void *)instanceName);
-  instanceName = NULL;
+	free((void *)instanceName);
+	instanceName = NULL;
 }
 
 static void mdnsTxtCallback(struct mdns_service *service, void *userdata) {
-  size_t index = (size_t)userdata;
-  if (index >= records.size())
-    return;
+	size_t index = (size_t)userdata;
+	if (index >= records.size())
+		return;
 
-  for (const auto record : records[index]) {
-    err_t err = mdns_resp_add_service_txtitem(service, record, strlen(record));
-    if (err != ERR_OK) {
-      LT_DM(MDNS, "Error %d while adding txt record: %s", err, record);
-    }
-  }
+	for (const auto record : records[index]) {
+		err_t err = mdns_resp_add_service_txtitem(service, record, strlen(record));
+		if (err != ERR_OK) {
+			LT_DM(MDNS, "Error %d while adding txt record: %s", err, record);
+		}
+	}
 }
 
 static void mdnsStatusCallback(struct netif *netif, uint8_t result) {
-  LT_DM(MDNS, "Status: netif %u, status %u", netif->num, result);
+	LT_DM(MDNS, "Status: netif %u, status %u", netif->num, result);
 }
 
 #ifdef LWIP_NETIF_EXT_STATUS_CALLBACK
 static void addServices(struct netif *netif) {
-  for (uint8_t i = 0; i < services.size(); i++) {
-    LT_DM(MDNS, "Add service: netif %u / %s / %s / %u / %u", netif->num,
-          services_name[i], services[i], protos[i], ports[i]);
-    mdns_resp_add_service(
-        netif, services_name[i], services[i], (mdns_sd_proto)protos[i],
-        ports[i], 255, mdnsTxtCallback,
-        reinterpret_cast<void *>(i) // index of newly added service
-    );
-  }
+	for (uint8_t i = 0; i < services.size(); i++) {
+		LT_DM(
+			MDNS,
+			"Add service: netif %u / %s / %s / %u / %u",
+			netif->num,
+			services_name[i],
+			services[i],
+			protos[i],
+			ports[i]
+		);
+		mdns_resp_add_service(
+			netif,
+			services_name[i],
+			services[i],
+			(mdns_sd_proto)protos[i],
+			ports[i],
+			255,
+			mdnsTxtCallback,
+			reinterpret_cast<void *>(i) // index of newly added service
+		);
+	}
 }
 #endif
 
 static bool enableMDNS(struct netif *netif) {
-  if (netif_is_up(netif)) {
-    LT_DM(MDNS, "Starting mDNS on netif %u", netif->num);
-    if ((netif->flags & NETIF_FLAG_IGMP) == 0) {
-      netif->flags |= NETIF_FLAG_IGMP;
-      igmp_start(netif);
-      LT_DM(MDNS, "Added IGMP to netif %u", netif->num);
-    }
-    err_t ret = mdns_resp_add_netif(netif, hostName, 255);
-    if (ret == ERR_OK) {
-      LT_DM(MDNS, "mDNS started on netif %u, announcing it to network",
-            netif->num);
+	if (netif_is_up(netif)) {
+		LT_DM(MDNS, "Starting mDNS on netif %u", netif->num);
+		if ((netif->flags & NETIF_FLAG_IGMP) == 0) {
+			netif->flags |= NETIF_FLAG_IGMP;
+			igmp_start(netif);
+			LT_DM(MDNS, "Added IGMP to netif %u", netif->num);
+		}
+		err_t ret = mdns_resp_add_netif(netif, hostName, 255);
+		if (ret == ERR_OK) {
+			LT_DM(MDNS, "mDNS started on netif %u, announcing it to network", netif->num);
 #if LWIP_VERSION_SIMPLE >= 20100
-      mdns_resp_announce(netif);
+			mdns_resp_announce(netif);
 #else
 #warning "lwIP version older than 2.1.0, mdns_resp_announce() unavailable"
 #endif
-      return true;
-    } else {
-      LT_DM(MDNS, "Cannot start mDNS on netif %u; ret=%d, errno=%d", netif->num,
-            ret, errno);
-    }
-  }
-  return false;
+			return true;
+		} else {
+			LT_DM(MDNS, "Cannot start mDNS on netif %u; ret=%d, errno=%d", netif->num, ret, errno);
+		}
+	}
+	return false;
 }
 
 #ifdef LWIP_NETIF_EXT_STATUS_CALLBACK
 static void
-mdns_netif_ext_status_callback(struct netif *netif, netif_nsc_reason_t reason,
-                               const netif_ext_callback_args_t *args) {
-  if (reason & LWIP_NSC_NETIF_REMOVED) {
-    LT_DM(MDNS, "Netif removed, stopping mDNS on netif %u", netif->num);
-    mdns_resp_remove_netif(netif);
-  } else if (reason & LWIP_NSC_STATUS_CHANGED) {
-    LT_DM(MDNS, "Netif changed, starting mDNS on netif %u", netif->num);
-    if (enableMDNS(netif) && services.size() > 0) {
-      LT_DM(MDNS, "Adding services to netif %u", netif->num);
-      addServices(netif);
-    }
-  }
+mdns_netif_ext_status_callback(struct netif *netif, netif_nsc_reason_t reason, const netif_ext_callback_args_t *args) {
+	if (reason & LWIP_NSC_NETIF_REMOVED) {
+		LT_DM(MDNS, "Netif removed, stopping mDNS on netif %u", netif->num);
+		mdns_resp_remove_netif(netif);
+	} else if (reason & LWIP_NSC_STATUS_CHANGED) {
+		LT_DM(MDNS, "Netif changed, starting mDNS on netif %u", netif->num);
+		if (enableMDNS(netif) && services.size() > 0) {
+			LT_DM(MDNS, "Adding services to netif %u", netif->num);
+			addServices(netif);
+		}
+	}
 }
 #endif
 
 bool mDNS::begin(const char *hostname) {
-  hostName = strdup(hostname);
-  setInstanceName(hostname);
+	hostName = strdup(hostname);
+	setInstanceName(hostname);
 #ifdef LWIP_NETIF_EXT_STATUS_CALLBACK
-  netif_add_ext_callback(&netif_callback, mdns_netif_ext_status_callback);
+	netif_add_ext_callback(&netif_callback, mdns_netif_ext_status_callback);
 #endif
-  LT_DM(MDNS, "Starting (%s)", hostname);
+	LT_DM(MDNS, "Starting (%s)", hostname);
 #if LWIP_VERSION_MAJOR >= 2 && LWIP_VERSION_MINOR >= 1
-  mdns_resp_register_name_result_cb(mdnsStatusCallback);
+	mdns_resp_register_name_result_cb(mdnsStatusCallback);
 #endif
-  mdns_resp_init();
-  struct netif *netif;
-  for (netif = netif_list; netif != NULL; netif = netif->next) {
-    enableMDNS(netif);
-  }
-  return true;
+	mdns_resp_init();
+	struct netif *netif;
+	for (netif = netif_list; netif != NULL; netif = netif->next) {
+		enableMDNS(netif);
+	}
+	return true;
 }
 
 void mDNS::end() {
 #ifdef LWIP_NETIF_EXT_STATUS_CALLBACK
-  netif_remove_ext_callback(&netif_callback);
+	netif_remove_ext_callback(&netif_callback);
 #endif
 
-  struct netif *netif = netif_list;
-  while (netif != NULL) {
-    if (netif_is_up(netif))
-      mdns_resp_remove_netif(netif);
-    netif = netif->next;
-  }
+	struct netif *netif = netif_list;
+	while (netif != NULL) {
+		if (netif_is_up(netif))
+			mdns_resp_remove_netif(netif);
+		netif = netif->next;
+	}
 
-  cleanup();
+	cleanup();
 }
 
-bool mDNS::addServiceImpl(const char *name, const char *service, uint8_t proto,
-                          uint16_t port) {
-  bool added = false;
-  struct netif *netif = netif_list;
-  while (netif != NULL) {
-    if (netif_is_up(netif)) {
-      // register TXT callback;
-      // pass service index as userdata parameter
-      LT_DM(MDNS, "Add service: netif %u / %s / %s / %u / %u", netif->num, name,
-            service, proto, port);
-      mdns_resp_add_service(
-          netif, name, service, (mdns_sd_proto)proto, port, 255,
-          mdnsTxtCallback,
-          (void *)services.size() // index of newly added service
-      );
-      added = true;
-    }
-    netif = netif->next;
-  }
+bool mDNS::addServiceImpl(const char *name, const char *service, uint8_t proto, uint16_t port) {
+	bool added			= false;
+	struct netif *netif = netif_list;
+	while (netif != NULL) {
+		if (netif_is_up(netif)) {
+			// register TXT callback;
+			// pass service index as userdata parameter
+			LT_DM(MDNS, "Add service: netif %u / %s / %s / %u / %u", netif->num, name, service, proto, port);
+			mdns_resp_add_service(
+				netif,
+				name,
+				service,
+				(mdns_sd_proto)proto,
+				port,
+				255,
+				mdnsTxtCallback,
+				(void *)services.size() // index of newly added service
+			);
+			added = true;
+		}
+		netif = netif->next;
+	}
 
-  if (!added)
-    return false;
+	if (!added)
+		return false;
 
-  // add the service to TXT record arrays
-  services_name.push_back(strdup(name));
-  services.push_back(strdup(service));
-  protos.push_back(proto);
-  ports.push_back(port);
-  records.emplace_back();
+	// add the service to TXT record arrays
+	services_name.push_back(strdup(name));
+	services.push_back(strdup(service));
+	protos.push_back(proto);
+	ports.push_back(port);
+	records.emplace_back();
 
-  return true;
+	return true;
 }
 
-bool mDNS::addServiceTxtImpl(const char *service, uint8_t proto,
-                             const char *item) {
-  uint8_t i;
-  for (i = 0; i < services.size(); i++) {
-    // find a matching service
-    if (strcmp(services[i], service) == 0 && protos[i] == proto) {
-      break;
-    }
-  }
-  if (i == services.size())
-    return false;
+bool mDNS::addServiceTxtImpl(const char *service, uint8_t proto, const char *item) {
+	uint8_t i;
+	for (i = 0; i < services.size(); i++) {
+		// find a matching service
+		if (strcmp(services[i], service) == 0 && protos[i] == proto) {
+			break;
+		}
+	}
+	if (i == services.size())
+		return false;
 
-  records[i].push_back(strdup(item));
-  return true;
+	records[i].push_back(strdup(item));
+	return true;
 }
 
 MDNSResponder MDNS;

--- a/cores/common/arduino/libraries/common/mDNS/LwIPmDNS.cpp
+++ b/cores/common/arduino/libraries/common/mDNS/LwIPmDNS.cpp
@@ -32,198 +32,186 @@ NETIF_DECLARE_EXT_CALLBACK(netif_callback)
 #endif
 
 static inline void freeAllocatedStrings(const std::vector<char *> &strings) {
-	for (auto &str : strings) {
-		free(str);
-	}
+  for (auto &str : strings) {
+    free(str);
+  }
 }
 
 mDNS::mDNS() {}
 
-mDNS::~mDNS() {
-	cleanup();
-}
+mDNS::~mDNS() { cleanup(); }
 
 void mDNS::cleanup() {
-	freeAllocatedStrings(services_name);
-	services_name.clear();
-	freeAllocatedStrings(services);
-	services.clear();
-	for (auto &record : records) {
-		freeAllocatedStrings(record);
-	}
-	records.clear();
+  freeAllocatedStrings(services_name);
+  services_name.clear();
+  freeAllocatedStrings(services);
+  services.clear();
+  for (auto &record : records) {
+    freeAllocatedStrings(record);
+  }
+  records.clear();
 
-	free((void *)hostName);
-	hostName = NULL;
+  free((void *)hostName);
+  hostName = NULL;
 
-	free((void *)instanceName);
-	instanceName = NULL;
+  free((void *)instanceName);
+  instanceName = NULL;
 }
 
 static void mdnsTxtCallback(struct mdns_service *service, void *userdata) {
-	size_t index = (size_t)userdata;
-	if (index >= records.size())
-		return;
+  size_t index = (size_t)userdata;
+  if (index >= records.size())
+    return;
 
-	for (const auto record : records[index]) {
-		err_t err = mdns_resp_add_service_txtitem(service, record, strlen(record));
-		if (err != ERR_OK)
-			return;
-	}
+  for (const auto record : records[index]) {
+    err_t err = mdns_resp_add_service_txtitem(service, record, strlen(record));
+    if (err != ERR_OK) {
+      LT_DM(MDNS, "Error %d while adding txt record: %s", err, record);
+    }
+  }
 }
 
 static void mdnsStatusCallback(struct netif *netif, uint8_t result) {
-	LT_DM(MDNS, "Status: netif %u, status %u", netif->num, result);
+  LT_DM(MDNS, "Status: netif %u, status %u", netif->num, result);
 }
 
 #ifdef LWIP_NETIF_EXT_STATUS_CALLBACK
 static void addServices(struct netif *netif) {
-	for (uint8_t i = 0; i < services.size(); i++) {
-		LT_DM(
-			MDNS,
-			"Add service: netif %u / %s / %s / %u / %u",
-			netif->num,
-			services_name[i],
-			services[i],
-			protos[i],
-			ports[i]
-		);
-		mdns_resp_add_service(
-			netif,
-			services_name[i],
-			services[i],
-			(mdns_sd_proto)protos[i],
-			ports[i],
-			255,
-			mdnsTxtCallback,
-			reinterpret_cast<void *>(i) // index of newly added service
-		);
-	}
+  for (uint8_t i = 0; i < services.size(); i++) {
+    LT_DM(MDNS, "Add service: netif %u / %s / %s / %u / %u", netif->num,
+          services_name[i], services[i], protos[i], ports[i]);
+    mdns_resp_add_service(
+        netif, services_name[i], services[i], (mdns_sd_proto)protos[i],
+        ports[i], 255, mdnsTxtCallback,
+        reinterpret_cast<void *>(i) // index of newly added service
+    );
+  }
 }
 #endif
 
 static bool enableMDNS(struct netif *netif) {
-	if (netif_is_up(netif)) {
-		LT_DM(MDNS, "Starting mDNS on netif %u", netif->num);
-		if ((netif->flags & NETIF_FLAG_IGMP) == 0) {
-			netif->flags |= NETIF_FLAG_IGMP;
-			igmp_start(netif);
-			LT_DM(MDNS, "Added IGMP to netif %u", netif->num);
-		}
-		err_t ret = mdns_resp_add_netif(netif, hostName, 255);
-		if (ret == ERR_OK) {
-			LT_DM(MDNS, "mDNS started on netif %u, announcing it to network", netif->num);
+  if (netif_is_up(netif)) {
+    LT_DM(MDNS, "Starting mDNS on netif %u", netif->num);
+    if ((netif->flags & NETIF_FLAG_IGMP) == 0) {
+      netif->flags |= NETIF_FLAG_IGMP;
+      igmp_start(netif);
+      LT_DM(MDNS, "Added IGMP to netif %u", netif->num);
+    }
+    err_t ret = mdns_resp_add_netif(netif, hostName, 255);
+    if (ret == ERR_OK) {
+      LT_DM(MDNS, "mDNS started on netif %u, announcing it to network",
+            netif->num);
 #if LWIP_VERSION_SIMPLE >= 20100
-			mdns_resp_announce(netif);
+      mdns_resp_announce(netif);
 #else
 #warning "lwIP version older than 2.1.0, mdns_resp_announce() unavailable"
 #endif
-			return true;
-		} else {
-			LT_DM(MDNS, "Cannot start mDNS on netif %u; ret=%d, errno=%d", netif->num, ret, errno);
-		}
-	}
-	return false;
+      return true;
+    } else {
+      LT_DM(MDNS, "Cannot start mDNS on netif %u; ret=%d, errno=%d", netif->num,
+            ret, errno);
+    }
+  }
+  return false;
 }
 
 #ifdef LWIP_NETIF_EXT_STATUS_CALLBACK
 static void
-mdns_netif_ext_status_callback(struct netif *netif, netif_nsc_reason_t reason, const netif_ext_callback_args_t *args) {
-	if (reason & LWIP_NSC_NETIF_REMOVED) {
-		LT_DM(MDNS, "Netif removed, stopping mDNS on netif %u", netif->num);
-		mdns_resp_remove_netif(netif);
-	} else if (reason & LWIP_NSC_STATUS_CHANGED) {
-		LT_DM(MDNS, "Netif changed, starting mDNS on netif %u", netif->num);
-		if (enableMDNS(netif) && services.size() > 0) {
-			LT_DM(MDNS, "Adding services to netif %u", netif->num);
-			addServices(netif);
-		}
-	}
+mdns_netif_ext_status_callback(struct netif *netif, netif_nsc_reason_t reason,
+                               const netif_ext_callback_args_t *args) {
+  if (reason & LWIP_NSC_NETIF_REMOVED) {
+    LT_DM(MDNS, "Netif removed, stopping mDNS on netif %u", netif->num);
+    mdns_resp_remove_netif(netif);
+  } else if (reason & LWIP_NSC_STATUS_CHANGED) {
+    LT_DM(MDNS, "Netif changed, starting mDNS on netif %u", netif->num);
+    if (enableMDNS(netif) && services.size() > 0) {
+      LT_DM(MDNS, "Adding services to netif %u", netif->num);
+      addServices(netif);
+    }
+  }
 }
 #endif
 
 bool mDNS::begin(const char *hostname) {
-	hostName = strdup(hostname);
-	setInstanceName(hostname);
+  hostName = strdup(hostname);
+  setInstanceName(hostname);
 #ifdef LWIP_NETIF_EXT_STATUS_CALLBACK
-	netif_add_ext_callback(&netif_callback, mdns_netif_ext_status_callback);
+  netif_add_ext_callback(&netif_callback, mdns_netif_ext_status_callback);
 #endif
-	LT_DM(MDNS, "Starting (%s)", hostname);
+  LT_DM(MDNS, "Starting (%s)", hostname);
 #if LWIP_VERSION_MAJOR >= 2 && LWIP_VERSION_MINOR >= 1
-	mdns_resp_register_name_result_cb(mdnsStatusCallback);
+  mdns_resp_register_name_result_cb(mdnsStatusCallback);
 #endif
-	mdns_resp_init();
-	struct netif *netif;
-	for (netif = netif_list; netif != NULL; netif = netif->next) {
-		enableMDNS(netif);
-	}
-	return true;
+  mdns_resp_init();
+  struct netif *netif;
+  for (netif = netif_list; netif != NULL; netif = netif->next) {
+    enableMDNS(netif);
+  }
+  return true;
 }
 
 void mDNS::end() {
 #ifdef LWIP_NETIF_EXT_STATUS_CALLBACK
-	netif_remove_ext_callback(&netif_callback);
+  netif_remove_ext_callback(&netif_callback);
 #endif
 
-	struct netif *netif = netif_list;
-	while (netif != NULL) {
-		if (netif_is_up(netif))
-			mdns_resp_remove_netif(netif);
-		netif = netif->next;
-	}
+  struct netif *netif = netif_list;
+  while (netif != NULL) {
+    if (netif_is_up(netif))
+      mdns_resp_remove_netif(netif);
+    netif = netif->next;
+  }
 
-	cleanup();
+  cleanup();
 }
 
-bool mDNS::addServiceImpl(const char *name, const char *service, uint8_t proto, uint16_t port) {
-	bool added			= false;
-	struct netif *netif = netif_list;
-	while (netif != NULL) {
-		if (netif_is_up(netif)) {
-			// register TXT callback;
-			// pass service index as userdata parameter
-			LT_DM(MDNS, "Add service: netif %u / %s / %s / %u / %u", netif->num, name, service, proto, port);
-			mdns_resp_add_service(
-				netif,
-				name,
-				service,
-				(mdns_sd_proto)proto,
-				port,
-				255,
-				mdnsTxtCallback,
-				(void *)services.size() // index of newly added service
-			);
-			added = true;
-		}
-		netif = netif->next;
-	}
+bool mDNS::addServiceImpl(const char *name, const char *service, uint8_t proto,
+                          uint16_t port) {
+  bool added = false;
+  struct netif *netif = netif_list;
+  while (netif != NULL) {
+    if (netif_is_up(netif)) {
+      // register TXT callback;
+      // pass service index as userdata parameter
+      LT_DM(MDNS, "Add service: netif %u / %s / %s / %u / %u", netif->num, name,
+            service, proto, port);
+      mdns_resp_add_service(
+          netif, name, service, (mdns_sd_proto)proto, port, 255,
+          mdnsTxtCallback,
+          (void *)services.size() // index of newly added service
+      );
+      added = true;
+    }
+    netif = netif->next;
+  }
 
-	if (!added)
-		return false;
+  if (!added)
+    return false;
 
-	// add the service to TXT record arrays
-	services_name.push_back(strdup(name));
-	services.push_back(strdup(service));
-	protos.push_back(proto);
-	ports.push_back(port);
-	records.emplace_back();
+  // add the service to TXT record arrays
+  services_name.push_back(strdup(name));
+  services.push_back(strdup(service));
+  protos.push_back(proto);
+  ports.push_back(port);
+  records.emplace_back();
 
-	return true;
+  return true;
 }
 
-bool mDNS::addServiceTxtImpl(const char *service, uint8_t proto, const char *item) {
-	uint8_t i;
-	for (i = 0; i < services.size(); i++) {
-		// find a matching service
-		if (strcmp(services[i], service) == 0 && protos[i] == proto) {
-			break;
-		}
-	}
-	if (i == services.size())
-		return false;
+bool mDNS::addServiceTxtImpl(const char *service, uint8_t proto,
+                             const char *item) {
+  uint8_t i;
+  for (i = 0; i < services.size(); i++) {
+    // find a matching service
+    if (strcmp(services[i], service) == 0 && protos[i] == proto) {
+      break;
+    }
+  }
+  if (i == services.size())
+    return false;
 
-	records[i].push_back(strdup(item));
-	return true;
+  records[i].push_back(strdup(item));
+  return true;
 }
 
 MDNSResponder MDNS;

--- a/cores/common/arduino/libraries/common/mDNS/mDNS.cpp
+++ b/cores/common/arduino/libraries/common/mDNS/mDNS.cpp
@@ -15,7 +15,7 @@ static char *ensureUnderscore(char *value) {
 
 static inline void freeIfCopied(const char *original, char *duplicate) {
 	if ((duplicate) && (original != duplicate)) {
-		free((void *)duplicate);
+		free(duplicate);
 	}
 }
 

--- a/cores/common/arduino/libraries/common/mDNS/mDNS.cpp
+++ b/cores/common/arduino/libraries/common/mDNS/mDNS.cpp
@@ -3,7 +3,7 @@
 #include "mDNS.h"
 
 static char *ensureUnderscore(const char *value) {
-	uint8_t len	 = strlen(value) + 1;
+	uint8_t len	 = strlen(value) + 1 + 1;	// 1 for underscore, 1 for null-terminator
 	char *result = (char *)malloc(len);
 	result[0]	 = '_';
 	strcpy(result + 1, value + (value[0] == '_'));

--- a/cores/common/arduino/libraries/common/mDNS/mDNS.cpp
+++ b/cores/common/arduino/libraries/common/mDNS/mDNS.cpp
@@ -3,7 +3,7 @@
 #include "mDNS.h"
 
 static char *ensureUnderscore(const char *value) {
-	uint8_t len	 = strlen(value) + 1 + 1; // 1 for underscore, 1 for null-terminator
+	uint8_t len	 = strlen(value) + (value[0] != '_') + 1; // 1 for underscore (if needed), 1 for null-terminator
 	char *result = (char *)malloc(len);
 	result[0]	 = '_';
 	strcpy(result + 1, value + (value[0] == '_'));

--- a/cores/common/arduino/libraries/common/mDNS/mDNS.cpp
+++ b/cores/common/arduino/libraries/common/mDNS/mDNS.cpp
@@ -13,7 +13,7 @@ static const char *ensureUnderscore(const char *value) {
 	return result;
 }
 
-static void freeIfDuplicate(const char *original, const char *duplicate) {
+static inline void freeIfCopied(const char *original, const char *duplicate) {
 	if ((duplicate) && (original != duplicate)) {
 		free((void *)duplicate);
 	}
@@ -30,7 +30,7 @@ bool mDNS::addService(char *service, char *proto, uint16_t port) {
 	uint8_t _proto = strncmp(proto + (proto[0] == '_'), "tcp", 3) == 0 ? MDNS_TCP : MDNS_UDP;
 
 	bool result = addServiceImpl(instanceName ? instanceName : "LT mDNS", _service, _proto, port);
-	freeIfDuplicate(service, _service);
+	freeIfCopied(service, _service);
 	return result;
 }
 
@@ -43,7 +43,7 @@ bool mDNS::addServiceTxt(char *service, char *proto, char *key, char *value) {
 	sprintf(txt, "%s=%s", key, value);
 
 	bool result = addServiceTxtImpl(_service, _proto, txt);
-	freeIfDuplicate(service, _service);
+	freeIfCopied(service, _service);
 	free(txt);
 	return result;
 }

--- a/cores/common/arduino/libraries/common/mDNS/mDNS.cpp
+++ b/cores/common/arduino/libraries/common/mDNS/mDNS.cpp
@@ -2,7 +2,7 @@
 
 #include "mDNS.h"
 
-static const char *ensureUnderscore(const char *value) {
+static char *ensureUnderscore(char *value) {
 	if (value[0] == '_') {
 		return value;
 	}
@@ -13,7 +13,7 @@ static const char *ensureUnderscore(const char *value) {
 	return result;
 }
 
-static inline void freeIfCopied(const char *original, const char *duplicate) {
+static inline void freeIfCopied(const char *original, char *duplicate) {
 	if ((duplicate) && (original != duplicate)) {
 		free((void *)duplicate);
 	}
@@ -26,8 +26,8 @@ void mDNS::setInstanceName(const char *name) {
 }
 
 bool mDNS::addService(char *service, char *proto, uint16_t port) {
-	const char *_service = ensureUnderscore(service);
-	uint8_t _proto		 = strncmp(proto + (proto[0] == '_'), "tcp", 3) == 0 ? MDNS_TCP : MDNS_UDP;
+	char *_service = ensureUnderscore(service);
+	uint8_t _proto = strncmp(proto + (proto[0] == '_'), "tcp", 3) == 0 ? MDNS_TCP : MDNS_UDP;
 
 	bool result = addServiceImpl(instanceName ? instanceName : "LT mDNS", _service, _proto, port);
 	freeIfCopied(service, _service);
@@ -35,8 +35,8 @@ bool mDNS::addService(char *service, char *proto, uint16_t port) {
 }
 
 bool mDNS::addServiceTxt(char *service, char *proto, char *key, char *value) {
-	const char *_service = ensureUnderscore(service);
-	uint8_t _proto		 = strncmp(proto + (proto[0] == '_'), "tcp", 3) == 0 ? MDNS_TCP : MDNS_UDP;
+	char *_service = ensureUnderscore(service);
+	uint8_t _proto = strncmp(proto + (proto[0] == '_'), "tcp", 3) == 0 ? MDNS_TCP : MDNS_UDP;
 
 	uint8_t txt_len = strlen(key) + strlen(value) + 1;
 	char *txt		= (char *)malloc(txt_len + 1);

--- a/cores/common/arduino/libraries/common/mDNS/mDNS.cpp
+++ b/cores/common/arduino/libraries/common/mDNS/mDNS.cpp
@@ -3,7 +3,7 @@
 #include "mDNS.h"
 
 static char *ensureUnderscore(const char *value) {
-	uint8_t len	 = strlen(value) + 1 + 1;	// 1 for underscore, 1 for null-terminator
+	uint8_t len	 = strlen(value) + 1 + 1; // 1 for underscore, 1 for null-terminator
 	char *result = (char *)malloc(len);
 	result[0]	 = '_';
 	strcpy(result + 1, value + (value[0] == '_'));

--- a/cores/common/arduino/libraries/common/mDNS/mDNS.cpp
+++ b/cores/common/arduino/libraries/common/mDNS/mDNS.cpp
@@ -26,8 +26,8 @@ void mDNS::setInstanceName(const char *name) {
 }
 
 bool mDNS::addService(char *service, char *proto, uint16_t port) {
-	char *_service = ensureUnderscore(service);
-	uint8_t _proto = strncmp(proto + (proto[0] == '_'), "tcp", 3) == 0 ? MDNS_TCP : MDNS_UDP;
+	const char *_service = ensureUnderscore(service);
+	uint8_t _proto		 = strncmp(proto + (proto[0] == '_'), "tcp", 3) == 0 ? MDNS_TCP : MDNS_UDP;
 
 	bool result = addServiceImpl(instanceName ? instanceName : "LT mDNS", _service, _proto, port);
 	freeIfCopied(service, _service);
@@ -35,8 +35,8 @@ bool mDNS::addService(char *service, char *proto, uint16_t port) {
 }
 
 bool mDNS::addServiceTxt(char *service, char *proto, char *key, char *value) {
-	char *_service = ensureUnderscore(service);
-	uint8_t _proto = strncmp(proto + (proto[0] == '_'), "tcp", 3) == 0 ? MDNS_TCP : MDNS_UDP;
+	const char *_service = ensureUnderscore(service);
+	uint8_t _proto		 = strncmp(proto + (proto[0] == '_'), "tcp", 3) == 0 ? MDNS_TCP : MDNS_UDP;
 
 	uint8_t txt_len = strlen(key) + strlen(value) + 1;
 	char *txt		= (char *)malloc(txt_len + 1);

--- a/cores/common/arduino/libraries/common/mDNS/mDNS.cpp
+++ b/cores/common/arduino/libraries/common/mDNS/mDNS.cpp
@@ -9,7 +9,7 @@ static const char *ensureUnderscore(const char *value) {
 	size_t len	 = strlen(value) + 1 + 1; // 1 for underscore, 1 for null-terminator
 	char *result = (char *)malloc(len);
 	result[0]	 = '_';
-	strcpy(result + 1, value + 1);
+	strcpy(result + 1, value);
 	return result;
 }
 

--- a/cores/common/arduino/libraries/common/mDNS/mDNS.h
+++ b/cores/common/arduino/libraries/common/mDNS/mDNS.h
@@ -51,6 +51,7 @@ class mDNS {
   private:
 	bool addServiceImpl(const char *name, const char *service, uint8_t proto, uint16_t port);
 	bool addServiceTxtImpl(const char *service, uint8_t proto, const char *item);
+	void cleanup();
 
 	char *instanceName = NULL;
 


### PR DESCRIPTION
strcpy() always adds null-terminator at the end.
The original code allocated one byte less than what is needed, so it was overwriting _something_. Could've been important or not :)
Found this while debugging #248, but I don't know if it fixes it or not. In my local tests on ubuntu I was not able to reproduce the behavior described in #248. But if it's memory related, then it's bound to behave differently on x86 + linux. Worth checking if it helped.
