### PR TITLE
Mdns more fixes

### DIFF
--- a/cores/common/arduino/libraries/common/mDNS/LwIPmDNS.cpp
+++ b/cores/common/arduino/libraries/common/mDNS/LwIPmDNS.cpp
@@ -184,7 +184,7 @@ bool mDNS::addServiceImpl(const char *name, const char *service, uint8_t proto, 
 			// register TXT callback;
 			// pass service index as userdata parameter
 			LT_DM(MDNS, "Add service: netif %u / %s / %s / %u / %u", netif->num, name, service, proto, port);
-			mdns_resp_add_service(
+			s8_t slot = mdns_resp_add_service(
 				netif,
 				name,
 				service,
@@ -194,13 +194,20 @@ bool mDNS::addServiceImpl(const char *name, const char *service, uint8_t proto, 
 				mdnsTxtCallback,
 				(void *)services.size() // index of newly added service
 			);
-			added = true;
+
+			if (slot < 0) {
+				LT_DM(MDNS, "mdns_resp_add_service returned error %d", slot);
+			} else {
+				added = true;
+			}
 		}
 		netif = netif->next;
 	}
 
 	if (!added)
 		return false;
+
+	// we end up here if service added to at least one interface
 
 	// add the service to TXT record arrays
 	services_name.push_back(strdup(name));

--- a/cores/common/arduino/libraries/common/mDNS/LwIPmDNS.cpp
+++ b/cores/common/arduino/libraries/common/mDNS/LwIPmDNS.cpp
@@ -183,6 +183,14 @@ void mDNS::end() {
 bool mDNS::addServiceImpl(const char *name, const char *service, uint8_t proto, uint16_t port) {
 	bool added			= false;
 	struct netif *netif = netif_list;
+
+	// add the service to TXT record arrays
+	services_name.push_back(strdup(name));
+	services.push_back(strdup(service));
+	protos.push_back(proto);
+	ports.push_back(port);
+	records.emplace_back();
+
 	while (netif != NULL) {
 		if (netif_is_up(netif)) {
 			// register TXT callback;
@@ -201,26 +209,14 @@ bool mDNS::addServiceImpl(const char *name, const char *service, uint8_t proto, 
 
 			if (slot < 0) {
 				LT_DM(MDNS, "mdns_resp_add_service returned error %d", slot);
-			} else {
-				added = true;
 			}
+
+			added = true;
 		}
 		netif = netif->next;
 	}
 
-	if (!added)
-		return false;
-
-	// we end up here if service added to at least one interface
-
-	// add the service to TXT record arrays
-	services_name.push_back(strdup(name));
-	services.push_back(strdup(service));
-	protos.push_back(proto);
-	ports.push_back(port);
-	records.emplace_back();
-
-	return true;
+	return added;
 }
 
 bool mDNS::addServiceTxtImpl(const char *service, uint8_t proto, const char *item) {

--- a/cores/common/arduino/libraries/common/mDNS/LwIPmDNS.cpp
+++ b/cores/common/arduino/libraries/common/mDNS/LwIPmDNS.cpp
@@ -137,8 +137,8 @@ mdns_netif_ext_status_callback(struct netif *netif, netif_nsc_reason_t reason, c
 	if (reason & LWIP_NSC_NETIF_REMOVED) {
 		LT_DM(MDNS, "Netif removed, stopping mDNS on netif %u", netif->num);
 		mdns_resp_remove_netif(netif);
-	} else if (reason & LWIP_NSC_STATUS_CHANGED) {
-		LT_DM(MDNS, "Netif changed, starting mDNS on netif %u", netif->num);
+	} else if ((reason & LWIP_NSC_STATUS_CHANGED) || (reason & LWIP_NSC_NETIF_ADDED)) {
+		LT_DM(MDNS, "Netif changed/added, starting mDNS on netif %u", netif->num);
 		if (enableMDNS(netif) && services.size() > 0) {
 			LT_DM(MDNS, "Adding services to netif %u", netif->num);
 			addServices(netif);

--- a/cores/common/arduino/libraries/common/mDNS/LwIPmDNS.cpp
+++ b/cores/common/arduino/libraries/common/mDNS/LwIPmDNS.cpp
@@ -89,7 +89,7 @@ static void addServices(struct netif *netif) {
 			protos[i],
 			ports[i]
 		);
-		mdns_resp_add_service(
+		s8_t slot = mdns_resp_add_service(
 			netif,
 			services_name[i],
 			services[i],
@@ -99,6 +99,10 @@ static void addServices(struct netif *netif) {
 			mdnsTxtCallback,
 			reinterpret_cast<void *>(i) // index of newly added service
 		);
+
+		if (slot < 0) {
+			LT_DM(MDNS, "mdns_resp_add_service returned error %d", slot);
+		}
 	}
 }
 #endif


### PR DESCRIPTION
I have noticed that if a service is not added to any net_if at the initial call to addServiceImpl(), then it is not stored at all. This is not correct, because a net_if might be nonexisting/down at the time, but later might be up and announced via mdns_netif_ext_status_callback. So all the services added via addServiceImpl should be cached always.
While fixing this I have noticed that the many static vectors can really be merged into a vector of CachedService structure - it makes usage much easier and it cleans-up after itself.

Tested this with some extent using a unit test and on a real device.