### PR TITLE
Added ability to specify WPA2 PSK in place of WiFi password

### DIFF
--- a/cores/beken-72xx/arduino/libraries/WiFi/WiFi.cpp
+++ b/cores/beken-72xx/arduino/libraries/WiFi/WiFi.cpp
@@ -6,7 +6,6 @@ WiFiClass::WiFiClass() {
 	data = (WiFiData *)calloc(1, sizeof(WiFiData));
 
 	DATA->scanSem		  = xSemaphoreCreateBinary();
-	STA_CFG.dhcp_mode	  = DHCP_CLIENT;
 	STA_ADV_CFG.dhcp_mode = DHCP_CLIENT;
 }
 

--- a/cores/beken-72xx/arduino/libraries/WiFi/WiFiGeneric.cpp
+++ b/cores/beken-72xx/arduino/libraries/WiFi/WiFiGeneric.cpp
@@ -71,7 +71,7 @@ WiFiMode WiFiClass::getMode() {
 
 WiFiStatus WiFiClass::status() {
 	rw_evt_type status = DATA->lastStaEvent;
-	if (status == RW_EVT_STA_CONNECTED && STA_CFG.dhcp_mode == DHCP_DISABLE)
+	if (status == RW_EVT_STA_CONNECTED && STA_ADV_CFG.dhcp_mode == DHCP_DISABLE)
 		status = RW_EVT_STA_GOT_IP;
 	return eventTypeToStatus(status);
 }

--- a/cores/beken-72xx/arduino/libraries/WiFi/WiFiPrivate.h
+++ b/cores/beken-72xx/arduino/libraries/WiFi/WiFiPrivate.h
@@ -56,7 +56,6 @@ extern void wifiEventHandler(rw_evt_type event);
 #define IP_FMT "%u.%u.%u.%u"
 
 typedef struct {
-	network_InitTypeDef_st configSta;
 	network_InitTypeDef_adv_st configStaAdv;
 	network_InitTypeDef_ap_st configAp;
 	unsigned long scannedAt;
@@ -73,7 +72,6 @@ typedef struct {
 #define pDATA ((WiFiData *)pWiFi->data)
 #define cDATA ((WiFiData *)cls->data)
 
-#define STA_CFG		(DATA->configSta)
 #define STA_ADV_CFG (DATA->configStaAdv)
 #define AP_CFG		(DATA->configAp)
 #define IP_STATUS	(DATA->statusIp)

--- a/cores/beken-72xx/base/fixups/wlan_ui.c
+++ b/cores/beken-72xx/base/fixups/wlan_ui.c
@@ -1,0 +1,150 @@
+#include "include.h"
+#include "wlan_ui_pub.h"
+#include "rw_pub.h"
+#include "param_config.h"
+#include "wpa_psk_cache.h"
+
+extern void bk_wlan_sta_init_adv(network_InitTypeDef_adv_st *inNetworkInitParaAdv);
+
+extern void bk_wlan_sta_adv_param_2_sta(network_InitTypeDef_adv_st *sta_adv,network_InitTypeDef_st* sta);
+
+OSStatus bk_wlan_start_sta_adv_fix(network_InitTypeDef_adv_st *inNetworkInitParaAdv)
+{
+    if (bk_wlan_is_monitor_mode()) {
+        os_printf("airkiss is not finish yet, stop airkiss or waiting it finish!\r\n");
+        return 0;
+    }
+
+#if !CFG_WPA_CTRL_IFACE
+#if CFG_ROLE_LAUNCH
+    rl_status_set_private_state(RL_PRIV_STATUS_STA_ADV_RDY);
+#endif
+#if CFG_ROLE_LAUNCH
+    rl_status_set_st_state(RL_ST_STATUS_RESTART_ST);
+#endif
+
+    bk_wlan_stop(BK_STATION);
+#if CFG_ROLE_LAUNCH
+    if (rl_pre_sta_set_status(RL_STATUS_STA_INITING))
+        return -1;
+
+    rl_status_reset_st_state(RL_ST_STATUS_RESTART_HOLD | RL_ST_STATUS_RESTART_ST);
+    rl_status_set_private_state(RL_PRIV_STATUS_STA_ADV);
+    rl_status_reset_private_state(RL_PRIV_STATUS_STA_ADV_RDY);
+    LAUNCH_REQ lreq;
+
+    lreq.req_type = LAUNCH_REQ_STA;
+    bk_wlan_sta_adv_param_2_sta(inNetworkInitParaAdv, &lreq.descr);
+
+    rl_sta_adv_register_cache_station(&lreq);
+#endif
+
+    bk_wlan_sta_init_adv(inNetworkInitParaAdv);
+
+    /*
+     * Key buffer is not guaranteed to be null terminated: there is a separate
+     * `key_len` field that stores the length. We have to copy the data to a
+     * temporary stack buffer. Fortunately, `wpa_psk_request()` does not keep
+     * the reference, as it's not needed: the end result is PSK that is either
+     * derived from the `ssid` + `key` or is already available. `key` is just a
+     * transient argument.
+     */
+    {
+        char key_buffer[PMK_LEN + 1];
+
+        /* Make copy with a guaranteed null terminator. */
+        os_memcpy(key_buffer, g_sta_param_ptr->key, g_sta_param_ptr->key_len);
+        key_buffer[g_sta_param_ptr->key_len + 1] = '\0';
+
+        /*
+         * let wpa_psk_cal thread to caculate psk.
+         * XXX: If you know psk value, fill last two parameters of `wpa_psk_request()'.
+         */
+        wpa_psk_request(g_sta_param_ptr->ssid.array, g_sta_param_ptr->ssid.length,
+                        key_buffer, NULL, 0);
+    }
+
+    supplicant_main_entry(inNetworkInitParaAdv->ap_info.ssid);
+
+    net_wlan_add_netif(&g_sta_param_ptr->own_mac);
+
+
+#else /* CFG_WPA_CTRL_IFACE */
+    wlan_sta_config_t config;
+
+#if (CFG_SOC_NAME == SOC_BK7231N)
+    if (get_ate_mode_state()) {
+        // cunliang20210407 set blk_standby_cfg with blk_txen_cfg like txevm, qunshan confirmed
+        rwnx_cal_en_extra_txpa();
+    }
+#endif
+    bk_wlan_sta_init_adv(inNetworkInitParaAdv);
+
+    /*
+     * Key buffer is not guaranteed to be null terminated: there is a separate
+     * `key_len` field that stores the length. We have to copy the data to a
+     * temporary stack buffer. Fortunately, `wpa_psk_request()` does not keep
+     * the reference, as it's not needed: the end result is PSK that is either
+     * derived from the `ssid` + `key` or is already available. `key` is just a
+     * transient argument.
+     */
+    {
+        char key_buffer[PMK_LEN + 1];
+
+        /* Make copy with a guaranteed null terminator. */
+        os_memcpy(key_buffer, g_sta_param_ptr->key, g_sta_param_ptr->key_len);
+        key_buffer[g_sta_param_ptr->key_len + 1] = '\0';
+
+        /*
+         * let wpa_psk_cal thread to caculate psk.
+         * XXX: If you know psk value, fill last two parameters of `wpa_psk_request()'.
+         */
+        wpa_psk_request(g_sta_param_ptr->ssid.array, g_sta_param_ptr->ssid.length,
+                        key_buffer, NULL, 0);
+    }
+
+    /* disconnect previous connected network */
+    wlan_sta_disconnect();
+
+    /* start wpa_supplicant */
+    wlan_sta_enable();
+
+    /* set network parameters: ssid, passphase */
+    wlan_sta_set((uint8_t*)inNetworkInitParaAdv->ap_info.ssid, os_strlen(inNetworkInitParaAdv->ap_info.ssid),
+                 (uint8_t*)inNetworkInitParaAdv->key);
+
+    /* set fast connect bssid */
+    os_memset(&config, 0, sizeof(config));
+    /*
+     * This API has no way to communicate whether BSSID was supplied or not.
+     * So we will use an assumption that no valid endpoint will ever use the
+     * `00:00:00:00:00:00`. It's basically a MAC address and no valid device
+     * should ever use the value consisting of all zeroes.
+     *
+     * We have just zeroed out the `config` struct so we can use those zeroes
+     * for comparison with our input argument.
+     */
+    if (os_memcmp(config.u.bssid, inNetworkInitParaAdv->ap_info.bssid, ETH_ALEN)) {
+        os_memcpy(config.u.bssid, inNetworkInitParaAdv->ap_info.bssid, ETH_ALEN);
+        config.field = WLAN_STA_FIELD_BSSID;
+        wpa_ctrl_request(WPA_CTRL_CMD_STA_SET, &config);
+    }
+
+    /* set fast connect freq */
+    os_memset(&config, 0, sizeof(config));
+    config.u.channel = inNetworkInitParaAdv->ap_info.channel;
+    config.field = WLAN_STA_FIELD_FREQ;
+    wpa_ctrl_request(WPA_CTRL_CMD_STA_SET, &config);
+
+    /* connect to AP */
+    wlan_sta_connect(g_sta_param_ptr->fast_connect_set ? g_sta_param_ptr->fast_connect.chann : 0);
+
+#endif
+    ip_address_set(BK_STATION, inNetworkInitParaAdv->dhcp_mode,
+                   inNetworkInitParaAdv->local_ip_addr,
+                   inNetworkInitParaAdv->net_mask,
+                   inNetworkInitParaAdv->gateway_ip_addr,
+                   inNetworkInitParaAdv->dns_server_ip_addr);
+
+    return 0;
+}

--- a/cores/beken-72xx/base/sdk_extern.h
+++ b/cores/beken-72xx/base/sdk_extern.h
@@ -20,6 +20,7 @@ void uart_hw_set_change(uint8_t uport, bk_uart_config_t *uart_config);
 int uart_rx_callback_set(int uport, uart_callback callback, void *param);
 void sctrl_enter_rtos_deep_sleep(PS_DEEP_CTRL_PARAM *deep_param);
 void ps_delay(volatile UINT16 times);
+OSStatus bk_wlan_start_sta_adv_fix(network_InitTypeDef_adv_st *inNetworkInitParaAdv);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/cores/common/arduino/libraries/api/WiFi/WiFi.cpp
+++ b/cores/common/arduino/libraries/api/WiFi/WiFi.cpp
@@ -61,7 +61,7 @@ bool WiFiClass::validate(const char *ssid, const char *passphrase) {
 			LT_WM(WIFI, "Passphrase too short (%u)", length);
 			return false;
 		}
-		if (length > 63) {
+		if (length > 64) {
 			LT_WM(WIFI, "Passphrase too long (%u)", length);
 			return false;
 		}


### PR DESCRIPTION
This is a feature that's already supported by **ESP** devices. However, in case of Tuya devices (at least for **BK7231N**) it's invaluable as it can reduce the connect time by **4 seconds** or more. It's all because in order to start negotiation, each client is required to derive the **PSK** that is a function of **SSID** and **Password**. And it's a deterministic function: it can be calculated once, stored somewhere and used many times for the same pair of **SSID** and **Password**. Actually, looking at **BDK** it's obvious that native firmware does exactly that. It even has a caching system that from looks of it is capable of storing multiple records.

Saving and restoring connection parameters is a more complex feature that is not implemented by this PR. However, it can now be easily done with the fixes made in `bk_wlan_start_sta_adv_fix`. This PR allows user to manually pre-calculate **PSK** for each of hist networks and use them instead of plain passwords in YAML. Which already works with **ESP32**/**ESP8266**, but raises `Passphrase too long` error in **LibreTiny**: all due to **BDK** limitations that are now circumvented.

On my cb3s based door sensor, using `fast_connect: true` with pre-calculated **PSK** I have managed to achieve a boot-to-mqtt-and-sleep time that is faster than the original firmware (probably because of higher latency): around **1.25-1.40s**. Using a fixed **BSSID** and **channel** can push it down **1s** or less.

Additionally, this PR removes the need for two supplemental config structs in `WiFiClass`, `STA_CFG` and `STA_ADV_CFG`, in favor of the latter.

More info on **PSK** can be found here: https://jorisvr.nl/wpapsk.html