### PR TITLE
fix change interruptsnot supported on rtl8710b

### DIFF
--- a/cores/realtek-amb/arduino/src/wiring_irq.c
+++ b/cores/realtek-amb/arduino/src/wiring_irq.c
@@ -61,6 +61,9 @@ void attachInterruptParam(pin_size_t interruptNumber, voidFuncPtrParam callback,
 		case CHANGE:
 #if LT_RTL8720C
 			event = IRQ_FALL_RISE;
+// Prevents Change interrupt errors on RTL8710B chips.
+#elif LT_RTL8710B
+			event = IRQ_RISE;			
 #else
 			LT_W("CHANGE interrupts not supported");
 #endif


### PR DESCRIPTION
Apply [SuperXL2023](https://github.com/SuperXL2023) solution to " CHANGE interrupts not supported" on RTL8710B chips.
https://github.com/libretiny-eu/libretiny/issues/155#issuecomment-1826470433

Also closes issues #155, 
issue #167  and,
issue #267