### PR TITLE
[realtek-ambz2] Fix C linkage for sys_now() in lwipopts

### DIFF
--- a/cores/realtek-ambz2/base/config/lwipopts.h
+++ b/cores/realtek-ambz2/base/config/lwipopts.h
@@ -7,4 +7,11 @@
 #define sys_now sys_now_dummy
 #include_next "lwipopts.h"
 #undef sys_now
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern unsigned long sys_now(void);
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
fixes compiling/linking errors in esphome. I was using esphome 2024.5.4