### PR TITLE
[beken-72xx] Fix CHANGE interrupt logic

### DIFF
--- a/cores/beken-72xx/arduino/src/wiring_irq.c
+++ b/cores/beken-72xx/arduino/src/wiring_irq.c
@@ -53,11 +53,11 @@ void attachInterruptParam(pin_size_t interruptNumber, voidFuncPtrParam callback,
 			break;
 		case CHANGE:
 			if (gpio_input(pin->gpio)) {
-				event  = GPIO_INT_LEVEL_FALLING;
-				mode = FALLING;
+				event = GPIO_INT_LEVEL_FALLING;
+				mode  = FALLING;
 			} else {
 				event = GPIO_INT_LEVEL_RISING;
-				mode = RISING;
+				mode  = RISING;
 			}
 			change = true;
 			break;


### PR DESCRIPTION
The CHANGE implementation used the wrong logic (using gpioMode instead of irqMode to switch the interrupt edge).
It also changes the edge after calling the isr instead of before (to avoid signal changes while servicing the isr, though that would be bad anyway).
It also sets the initial edge based on the current level of the pin. 