### PR TITLE
[realtek-ambz2] Define PIN_SERIAL0_RX/TX for wbr3

### DIFF
--- a/boards/variants/wbr3.h
+++ b/boards/variants/wbr3.h
@@ -28,8 +28,10 @@
 // ------------
 #define PIN_SERIAL0_RX_0 12u // PIN_A12
 #define PIN_SERIAL0_RX_1 13u // PIN_A13
+#define PIN_SERIAL0_RX   13u // PIN_A13
 #define PIN_SERIAL0_TX_0 11u // PIN_A11
 #define PIN_SERIAL0_TX_1 14u // PIN_A14
+#define PIN_SERIAL0_TX   14u // PIN_A14
 #define PIN_SERIAL1_CTS  4u  // PIN_A4
 #define PIN_SERIAL1_RX_0 2u  // PIN_A2
 #define PIN_SERIAL1_RX_1 0u  // PIN_A0


### PR DESCRIPTION
This is necessary; `WBR3` is not in the `feature/i2c-spi` branch, and this fixes about `feature/realtek-update` without the concerns of `feature/i2c-spi` -- perhaps I misunderstand the relevant comment, however.

https://github.com/libretiny-eu/libretiny/issues/44#issuecomment-1792656300

https://github.com/baltpeter/libretiny/commit/a92983a608836a380adfeb76eaa968f1dcabf27b