### PR TITLE
[realtek-ambz2] Fix partition table & bootloader flashing via UART

### DIFF
--- a/builder/family/realtek-ambz2.py
+++ b/builder/family/realtek-ambz2.py
@@ -427,8 +427,8 @@ env.Replace(
         # same OTA images for flasher and device
         f"{image_firmware_is},{image_firmware_is}=device:ota1,ota2;flasher:ota1,ota2",
         # having flashed an application image, update the bootloader and partition table (incl. keys)
-        f"{image_bootloader}=device:boot;flasher:boot",
-        f"{image_part_table}=device:part_table;flasher:part_table",
+        f"{image_bootloader},{image_bootloader}=flasher:boot,boot",
+        f"{image_part_table},{image_part_table}=flasher:part_table,part_table",
         # clearing headers of the "other" OTA image (hence the indexes are swapped)
         f"{image_ota_clear},{image_ota_clear}=device:ota2,ota1;flasher:ota2,ota1",
     ],


### PR DESCRIPTION
Do not include partition table & bootloader in device schemes (consistent with other supported families). Fix partition table & bootloader marked as `SINGLE` instead of `DUAL_1/2` in the flasher scheme, thus skipped during flashing using `ltchiptool`.