### PR TITLE
[common] Make Serial RX buffer size configurable, increase default to 256 bytes

### DIFF
--- a/cores/beken-72xx/arduino/libraries/Serial/SerialPrivate.h
+++ b/cores/beken-72xx/arduino/libraries/Serial/SerialPrivate.h
@@ -6,9 +6,9 @@
 #include <sdk_private.h>
 
 typedef struct {
-	RingBuffer buf;
+	SerialRingBuffer buf;
 } SerialData;
 
 #define DATA ((SerialData *)data)
 #define BUF	 (DATA->buf)
-#define pBUF ((RingBuffer *)param)
+#define pBUF ((SerialRingBuffer *)param)

--- a/cores/common/arduino/libraries/api/Serial/Serial.h
+++ b/cores/common/arduino/libraries/api/Serial/Serial.h
@@ -8,6 +8,8 @@
 
 using namespace arduino;
 
+typedef RingBufferN<LT_SERIAL_BUFFER_SIZE> SerialRingBuffer;
+
 class SerialClass : public HardwareSerial {
   private:
 	uint32_t port;
@@ -18,7 +20,7 @@ class SerialClass : public HardwareSerial {
 	void *data;
 
   private:
-	RingBuffer *buf;
+	SerialRingBuffer *buf;
 	uint32_t baudrate;
 	uint16_t config;
 

--- a/cores/common/arduino/libraries/api/SoftwareSerial/SoftwareSerial.h
+++ b/cores/common/arduino/libraries/api/SoftwareSerial/SoftwareSerial.h
@@ -27,7 +27,7 @@ typedef enum {
 
 typedef struct {
 	SoftState state;
-	RingBuffer *buf;
+	SerialRingBuffer *buf;
 	uint8_t byte;
 	pin_size_t pin;
 	void *param;

--- a/cores/common/base/lt_config.h
+++ b/cores/common/base/lt_config.h
@@ -77,6 +77,10 @@
 #define LT_UART_DEFAULT_SERIAL LT_UART_DEFAULT_PORT
 #endif
 
+#ifndef LT_SERIAL_BUFFER_SIZE
+#define LT_SERIAL_BUFFER_SIZE 256
+#endif
+
 // Misc options
 #ifndef LT_USE_TIME
 #define LT_USE_TIME 0

--- a/cores/realtek-amb/arduino/libraries/SoftwareSerial/SoftwareSerial.cpp
+++ b/cores/realtek-amb/arduino/libraries/SoftwareSerial/SoftwareSerial.cpp
@@ -63,8 +63,8 @@ void SoftwareSerial::begin(unsigned long baudrate, uint16_t config) {
 	pinMode(data.tx.pin, OUTPUT);
 	digitalWrite(data.tx.pin, HIGH);
 
-	data.rx.buf	  = new RingBuffer();
-	data.tx.buf	  = new RingBuffer();
+	data.rx.buf	  = new SerialRingBuffer();
+	data.tx.buf	  = new SerialRingBuffer();
 	data.rx.state = SS_IDLE;
 	data.tx.state = SS_IDLE;
 

--- a/cores/realtek-ambz/arduino/libraries/Serial/SerialPrivate.h
+++ b/cores/realtek-ambz/arduino/libraries/Serial/SerialPrivate.h
@@ -8,7 +8,7 @@
 typedef struct {
 	UART_TypeDef *uart;
 	IRQn irq;
-	RingBuffer buf;
+	SerialRingBuffer buf;
 } SerialData;
 
 #define DATA   ((SerialData *)data)

--- a/cores/realtek-ambz2/arduino/libraries/Serial/SerialPrivate.h
+++ b/cores/realtek-ambz2/arduino/libraries/Serial/SerialPrivate.h
@@ -7,7 +7,7 @@
 
 typedef struct {
 	hal_uart_adapter_t *uart;
-	RingBuffer buf;
+	SerialRingBuffer buf;
 } SerialData;
 
 #define DATA   ((SerialData *)data)


### PR DESCRIPTION
Increase RX buffer from 64 bytes to 256 bytes (ESPHome UART bus component default). Other sizes can easily be defined in ESPHome YAML e.g. like this:
```
bk72xx:
  board: cbu
  framework:
    options:
      LT_SERIAL_BUFFER_SIZE: 512
```

Preparatory work for https://github.com/esphome/issues/issues/6240. ESPHome could change `LT_SERIAL_BUFFER_SIZE` whenever `rx_buffer_size:` is changed.

Also covertly increases the send buffer for SoftwareSerial, but that should have no side effects.