### PR TITLE
[lightning-ln882h] Fix GPIO interrupt support

### DIFF
--- a/boards/_base/ic/ln882hk.json
+++ b/boards/_base/ic/ln882hk.json
@@ -49,6 +49,7 @@
 			"12": {
 				"C_NAME": "PA_4",
 				"GPIO": "PA04",
+				"IRQ": null,
 				"ADC": 4,
 				"SWD": "CLK",
 				"I2C": [
@@ -89,6 +90,7 @@
 			"16": {
 				"C_NAME": "PA_8",
 				"GPIO": "PA08",
+				"IRQ": null,
 				"CTRL": "BOOT0",
 				"SD": "CMD",
 				"I2S": "0_WS",
@@ -100,6 +102,7 @@
 			"17": {
 				"C_NAME": "PA_9",
 				"GPIO": "PA09",
+				"IRQ": null,
 				"CTRL": "BOOT1",
 				"SD": "CLK",
 				"I2S": "0_SCLK",
@@ -111,6 +114,7 @@
 			"21": {
 				"C_NAME": "PA_10",
 				"GPIO": "PA10",
+				"IRQ": null,
 				"SD": "D0",
 				"I2S": "0_TX",
 				"I2C": [
@@ -121,6 +125,7 @@
 			"22": {
 				"C_NAME": "PA_11",
 				"GPIO": "PA11",
+				"IRQ": null,
 				"SD": "D1",
 				"I2C": [
 					"0_SCL",
@@ -130,6 +135,7 @@
 			"23": {
 				"C_NAME": "PA_12",
 				"GPIO": "PA12",
+				"IRQ": null,
 				"I2C": [
 					"0_SCL",
 					"0_SDA"
@@ -139,6 +145,7 @@
 				"C_NAME": "PB_3",
 				"GPIO": "PB03",
 				"GPIONUM": 19,
+				"IRQ": null,
 				"ADC": 5,
 				"I2C": [
 					"0_SCL",
@@ -149,6 +156,7 @@
 				"C_NAME": "PB_4",
 				"GPIO": "PB04",
 				"GPIONUM": 20,
+				"IRQ": null,
 				"ADC": 6,
 				"I2C": [
 					"0_SCL",
@@ -159,6 +167,7 @@
 				"C_NAME": "PB_5",
 				"GPIO": "PB05",
 				"GPIONUM": 21,
+				"IRQ": null,
 				"ADC": 7,
 				"I2C": [
 					"0_SCL",
@@ -169,6 +178,7 @@
 				"C_NAME": "PB_6",
 				"GPIO": "PB06",
 				"GPIONUM": 22,
+				"IRQ": null,
 				"I2C": [
 					"0_SCL",
 					"0_SDA"
@@ -178,6 +188,7 @@
 				"C_NAME": "PB_7",
 				"GPIO": "PB07",
 				"GPIONUM": 23,
+				"IRQ": null,
 				"I2C": [
 					"0_SCL",
 					"0_SDA"
@@ -187,6 +198,7 @@
 				"C_NAME": "PB_8",
 				"GPIO": "PB08",
 				"GPIONUM": 24,
+				"IRQ": null,
 				"UART": "1_RX",
 				"I2C": [
 					"0_SCL",

--- a/boards/variants/generic-ln882hki.c
+++ b/boards/variants/generic-ln882hki.c
@@ -25,27 +25,27 @@ PinInfo lt_arduino_pin_info_list[PINS_COUNT] = {
 	// D7: PA07, SD_D3, I2S0_RX, I2C0_SCL, I2C0_SDA
 	{PA_7,  PIN_I2S | PIN_I2C | PIN_IRQ | PIN_GPIO,           PIN_NONE, 0},
 	// D8: PA08, BOOT0, SD_CMD, I2S0_WS, I2C0_SCL, I2C0_SDA
-	{PA_8,  PIN_I2S | PIN_I2C | PIN_GPIO,                     PIN_NONE, 0},
+	{PA_8,  PIN_I2S | PIN_I2C | PIN_IRQ | PIN_GPIO,           PIN_NONE, 0},
 	// D9: PA09, BOOT1, SD_CLK, I2S0_SCLK, I2C0_SCL, I2C0_SDA
-	{PA_9,  PIN_I2S | PIN_I2C | PIN_GPIO,                     PIN_NONE, 0},
+	{PA_9,  PIN_I2S | PIN_I2C | PIN_IRQ | PIN_GPIO,           PIN_NONE, 0},
 	// D10: PA10, SD_D0, I2S0_TX, I2C0_SCL, I2C0_SDA
-	{PA_10, PIN_I2S | PIN_I2C | PIN_GPIO,                     PIN_NONE, 0},
+	{PA_10, PIN_I2S | PIN_I2C | PIN_IRQ | PIN_GPIO,           PIN_NONE, 0},
 	// D11: PA11, SD_D1, I2C0_SCL, I2C0_SDA
-	{PA_11, PIN_I2C | PIN_GPIO,                               PIN_NONE, 0},
+	{PA_11, PIN_I2C | PIN_IRQ | PIN_GPIO,                     PIN_NONE, 0},
 	// D12: PA12, I2C0_SCL, I2C0_SDA
-	{PA_12, PIN_I2C | PIN_GPIO,                               PIN_NONE, 0},
+	{PA_12, PIN_I2C | PIN_IRQ | PIN_GPIO,                     PIN_NONE, 0},
 	// D13: PB03, ADC5, I2C0_SCL, I2C0_SDA
-	{PB_3,  PIN_I2C | PIN_ADC | PIN_GPIO,                     PIN_NONE, 0},
+	{PB_3,  PIN_I2C | PIN_ADC | PIN_IRQ | PIN_GPIO,           PIN_NONE, 0},
 	// D14: PB04, ADC6, I2C0_SCL, I2C0_SDA
-	{PB_4,  PIN_I2C | PIN_ADC | PIN_GPIO,                     PIN_NONE, 0},
+	{PB_4,  PIN_I2C | PIN_ADC | PIN_IRQ | PIN_GPIO,           PIN_NONE, 0},
 	// D15: PB05, ADC7, I2C0_SCL, I2C0_SDA
-	{PB_5,  PIN_I2C | PIN_ADC | PIN_GPIO,                     PIN_NONE, 0},
+	{PB_5,  PIN_I2C | PIN_ADC | PIN_IRQ | PIN_GPIO,           PIN_NONE, 0},
 	// D16: PB06, I2C0_SCL, I2C0_SDA
-	{PB_6,  PIN_I2C | PIN_GPIO,                               PIN_NONE, 0},
+	{PB_6,  PIN_I2C | PIN_IRQ | PIN_GPIO,                     PIN_NONE, 0},
 	// D17: PB07, I2C0_SCL, I2C0_SDA
-	{PB_7,  PIN_I2C | PIN_GPIO,                               PIN_NONE, 0},
+	{PB_7,  PIN_I2C | PIN_IRQ | PIN_GPIO,                     PIN_NONE, 0},
 	// D18: PB08, UART1_RX, I2C0_SCL, I2C0_SDA
-	{PB_8,  PIN_UART | PIN_I2C | PIN_GPIO,                    PIN_NONE, 0},
+	{PB_8,  PIN_UART | PIN_I2C | PIN_IRQ | PIN_GPIO,          PIN_NONE, 0},
 	// D19: PB09, UART1_TX, I2C0_SCL, I2C0_SDA
 	{PB_9,  PIN_UART | PIN_I2C | PIN_IRQ | PIN_GPIO,          PIN_NONE, 0},
 };

--- a/boards/variants/generic-ln882hki.c
+++ b/boards/variants/generic-ln882hki.c
@@ -17,7 +17,7 @@ PinInfo lt_arduino_pin_info_list[PINS_COUNT] = {
 	// D3: PA03, UART0_RX, I2C0_SCL, I2C0_SDA
 	{PA_3,  PIN_UART | PIN_I2C | PIN_IRQ | PIN_GPIO,          PIN_NONE, 0},
 	// D4: PA04, ADC4, SWCLK, I2C0_SCL, I2C0_SDA
-	{PA_4,  PIN_SWD | PIN_I2C | PIN_ADC | PIN_GPIO,           PIN_NONE, 0},
+	{PA_4,  PIN_SWD | PIN_I2C | PIN_ADC | PIN_IRQ | PIN_GPIO, PIN_NONE, 0},
 	// D5: PA05, I2C0_SCL, I2C0_SDA
 	{PA_5,  PIN_I2C | PIN_IRQ | PIN_GPIO,                     PIN_NONE, 0},
 	// D6: PA06, SD_D2, I2C0_SCL, I2C0_SDA

--- a/boards/variants/ln-02.c
+++ b/boards/variants/ln-02.c
@@ -9,13 +9,13 @@
 // clang-format off
 PinInfo lt_arduino_pin_info_list[PINS_COUNT] = {
 	// D0: PA11, SD_D1, I2C0_SCL, I2C0_SDA
-	{PA_11, PIN_I2C | PIN_GPIO,                               PIN_NONE, 0},
+	{PA_11, PIN_I2C | PIN_IRQ | PIN_GPIO,                     PIN_NONE, 0},
 	// D1: PB03, ADC5, I2C0_SCL, I2C0_SDA
-	{PB_3,  PIN_I2C | PIN_ADC | PIN_GPIO,                     PIN_NONE, 0},
+	{PB_3,  PIN_I2C | PIN_ADC | PIN_IRQ | PIN_GPIO,           PIN_NONE, 0},
 	// D2: PA03, UART0_RX, I2C0_SCL, I2C0_SDA
 	{PA_3,  PIN_UART | PIN_I2C | PIN_IRQ | PIN_GPIO,          PIN_NONE, 0},
 	// D3: PB08, UART1_RX, I2C0_SCL, I2C0_SDA
-	{PB_8,  PIN_UART | PIN_I2C | PIN_GPIO,                    PIN_NONE, 0},
+	{PB_8,  PIN_UART | PIN_I2C | PIN_IRQ | PIN_GPIO,          PIN_NONE, 0},
 	// D4: PA02, UART0_TX, I2C0_SCL, I2C0_SDA
 	{PA_2,  PIN_UART | PIN_I2C | PIN_IRQ | PIN_GPIO,          PIN_NONE, 0},
 	// D5: PB09, UART1_TX, I2C0_SCL, I2C0_SDA
@@ -25,7 +25,7 @@ PinInfo lt_arduino_pin_info_list[PINS_COUNT] = {
 	// D7: PA00, ADC2, I2C0_SCL, I2C0_SDA
 	{PA_0,  PIN_I2C | PIN_ADC | PIN_IRQ | PIN_GPIO,           PIN_NONE, 0},
 	// D8: PA09, BOOT1, SD_CLK, I2S0_SCLK, I2C0_SCL, I2C0_SDA
-	{PA_9,  PIN_I2S | PIN_I2C | PIN_GPIO,                     PIN_NONE, 0},
+	{PA_9,  PIN_I2S | PIN_I2C | PIN_IRQ | PIN_GPIO,           PIN_NONE, 0},
 };
 
 PinInfo *lt_arduino_pin_gpio_map[] = {

--- a/boards/variants/wl2s.c
+++ b/boards/variants/wl2s.c
@@ -11,23 +11,23 @@ PinInfo lt_arduino_pin_info_list[PINS_COUNT] = {
 	// D0: PA07, SD_D3, I2S0_RX, I2C0_SCL, I2C0_SDA
 	{PA_7,  PIN_I2S | PIN_I2C | PIN_IRQ | PIN_GPIO,           PIN_NONE, 0},
 	// D1: PA12, I2C0_SCL, I2C0_SDA
-	{PA_12, PIN_I2C | PIN_GPIO,                               PIN_NONE, 0},
+	{PA_12, PIN_I2C | PIN_IRQ | PIN_GPIO,                     PIN_NONE, 0},
 	// D2: PA03, UART0_RX, I2C0_SCL, I2C0_SDA
 	{PA_3,  PIN_UART | PIN_I2C | PIN_IRQ | PIN_GPIO,          PIN_NONE, 0},
 	// D3: PA10, SD_D0, I2S0_TX, I2C0_SCL, I2C0_SDA
-	{PA_10, PIN_I2S | PIN_I2C | PIN_GPIO,                     PIN_NONE, 0},
+	{PA_10, PIN_I2S | PIN_I2C | PIN_IRQ | PIN_GPIO,           PIN_NONE, 0},
 	// D4: PA02, UART0_TX, I2C0_SCL, I2C0_SDA
 	{PA_2,  PIN_UART | PIN_I2C | PIN_IRQ | PIN_GPIO,          PIN_NONE, 0},
 	// D5: PA00, ADC2, I2C0_SCL, I2C0_SDA
 	{PA_0,  PIN_I2C | PIN_ADC | PIN_IRQ | PIN_GPIO,           PIN_NONE, 0},
 	// D6: PB03, ADC5, I2C0_SCL, I2C0_SDA
-	{PB_3,  PIN_I2C | PIN_ADC | PIN_GPIO,                     PIN_NONE, 0},
+	{PB_3,  PIN_I2C | PIN_ADC | PIN_IRQ | PIN_GPIO,           PIN_NONE, 0},
 	// D7: PA11, SD_D1, I2C0_SCL, I2C0_SDA
-	{PA_11, PIN_I2C | PIN_GPIO,                               PIN_NONE, 0},
+	{PA_11, PIN_I2C | PIN_IRQ | PIN_GPIO,                     PIN_NONE, 0},
 	// D8: PA09, BOOT1, SD_CLK, I2S0_SCLK, I2C0_SCL, I2C0_SDA
-	{PA_9,  PIN_I2S | PIN_I2C | PIN_GPIO,                     PIN_NONE, 0},
+	{PA_9,  PIN_I2S | PIN_I2C | PIN_IRQ | PIN_GPIO,           PIN_NONE, 0},
 	// D9: PB08, UART1_RX, I2C0_SCL, I2C0_SDA
-	{PB_8,  PIN_UART | PIN_I2C | PIN_GPIO,                    PIN_NONE, 0},
+	{PB_8,  PIN_UART | PIN_I2C | PIN_IRQ | PIN_GPIO,          PIN_NONE, 0},
 	// D10: PB09, UART1_TX, I2C0_SCL, I2C0_SDA
 	{PB_9,  PIN_UART | PIN_I2C | PIN_IRQ | PIN_GPIO,          PIN_NONE, 0},
 	// D11: PA05, I2C0_SCL, I2C0_SDA

--- a/cores/lightning-ln882h/arduino/src/wiring_irq.c
+++ b/cores/lightning-ln882h/arduino/src/wiring_irq.c
@@ -89,8 +89,17 @@ void attachInterruptParam(pin_size_t interruptNumber, voidFuncPtrParam callback,
 void detachInterrupt(pin_size_t interruptNumber) {
 	pinCheckGetData(interruptNumber, PIN_IRQ, );
 
-	uint16_t IRQForPin = interruptNumber < 16 ? GPIOA_IRQn : GPIOB_IRQn;
-	NVIC_DisableIRQ(IRQForPin);
 	hal_gpio_pin_it_en(data->gpio_base, data->gpio->pin, HAL_DISABLE);
 	pinModeRemove(interruptNumber, PIN_IRQ);
+
+	//only call NVIC_DisableIRQ if no gpio in the same bank is using the interrupt
+	for (pin_size_t pinNumber = (interruptNumber < 16 ? 0 : 16); pinNumber < (interruptNumber < 16 ? 16 : 32); pinNumber++) {
+		PinInfo *pin = pinInfo(pinNumber);
+		if (!pin)
+			continue;
+		if (pinEnabled(pin, PIN_IRQ))
+			return;
+	}
+	uint16_t IRQForPin=interruptNumber < 16 ? GPIOA_IRQn : GPIOB_IRQn;
+	NVIC_DisableIRQ(IRQForPin);
 }

--- a/cores/lightning-ln882h/arduino/src/wiring_irq.c
+++ b/cores/lightning-ln882h/arduino/src/wiring_irq.c
@@ -81,15 +81,15 @@ void attachInterruptParam(pin_size_t interruptNumber, voidFuncPtrParam callback,
 
 	hal_gpio_pin_it_cfg(data->gpio_base, data->gpio->pin, event);
 	hal_gpio_pin_it_en(data->gpio_base, data->gpio->pin, HAL_ENABLE);
-	uint16_t IRQForPin=interruptNumber < 16 ? GPIOA_IRQn : GPIOB_IRQn;
-	NVIC_SetPriority(IRQForPin,1);
+	uint16_t IRQForPin = interruptNumber < 16 ? GPIOA_IRQn : GPIOB_IRQn;
+	NVIC_SetPriority(IRQForPin, 1);
 	NVIC_EnableIRQ(IRQForPin);
 }
 
 void detachInterrupt(pin_size_t interruptNumber) {
 	pinCheckGetData(interruptNumber, PIN_IRQ, );
 
-	uint16_t IRQForPin=interruptNumber < 16 ? GPIOA_IRQn : GPIOB_IRQn;
+	uint16_t IRQForPin = interruptNumber < 16 ? GPIOA_IRQn : GPIOB_IRQn;
 	NVIC_DisableIRQ(IRQForPin);
 	hal_gpio_pin_it_en(data->gpio_base, data->gpio->pin, HAL_DISABLE);
 	pinModeRemove(interruptNumber, PIN_IRQ);

--- a/cores/lightning-ln882h/arduino/src/wiring_irq.c
+++ b/cores/lightning-ln882h/arduino/src/wiring_irq.c
@@ -81,11 +81,16 @@ void attachInterruptParam(pin_size_t interruptNumber, voidFuncPtrParam callback,
 
 	hal_gpio_pin_it_cfg(data->gpio_base, data->gpio->pin, event);
 	hal_gpio_pin_it_en(data->gpio_base, data->gpio->pin, HAL_ENABLE);
+	uint16_t IRQForPin=interruptNumber < 16 ? GPIOA_IRQn : GPIOB_IRQn;
+	NVIC_SetPriority(IRQForPin,1);
+	NVIC_EnableIRQ(IRQForPin);
 }
 
 void detachInterrupt(pin_size_t interruptNumber) {
 	pinCheckGetData(interruptNumber, PIN_IRQ, );
 
+	uint16_t IRQForPin=interruptNumber < 16 ? GPIOA_IRQn : GPIOB_IRQn;
+	NVIC_DisableIRQ(IRQForPin);
 	hal_gpio_pin_it_en(data->gpio_base, data->gpio->pin, HAL_DISABLE);
 	pinModeRemove(interruptNumber, PIN_IRQ);
 }

--- a/cores/lightning-ln882h/arduino/src/wiring_irq.c
+++ b/cores/lightning-ln882h/arduino/src/wiring_irq.c
@@ -92,14 +92,14 @@ void detachInterrupt(pin_size_t interruptNumber) {
 	hal_gpio_pin_it_en(data->gpio_base, data->gpio->pin, HAL_DISABLE);
 	pinModeRemove(interruptNumber, PIN_IRQ);
 
-	//only call NVIC_DisableIRQ if no gpio in the same bank is using the interrupt
-	for (pin_size_t pinNumber = (interruptNumber < 16 ? 0 : 16); pinNumber < (interruptNumber < 16 ? 16 : 32); pinNumber++) {
+	for (pin_size_t pinNumber = (interruptNumber < 16 ? 0 : 16); pinNumber < (interruptNumber < 16 ? 16 : 32);
+		 pinNumber++) {
 		PinInfo *pin = pinInfo(pinNumber);
 		if (!pin)
 			continue;
 		if (pinEnabled(pin, PIN_IRQ))
 			return;
 	}
-	uint16_t IRQForPin=interruptNumber < 16 ? GPIOA_IRQn : GPIOB_IRQn;
+	uint16_t IRQForPin = interruptNumber < 16 ? GPIOA_IRQn : GPIOB_IRQn;
 	NVIC_DisableIRQ(IRQForPin);
 }

--- a/docs/status/supported.md
+++ b/docs/status/supported.md
@@ -49,7 +49,7 @@ Watchdog timer           | ✔️        | ✔️        | ✔️         | ❓ 
 **PERIPHERALS** (Wiring) |           |           |            |            |            |
 Digital I/O              | ✔️        | ✔️        | ✔️         | ❓          | ❓         | ✔️
 PWM                      | ✔️        | ✔️        | ✔️         | ❓          | ❓         | ❌
-Interrupts               | ✔️        | ✔️        | ✔️         | ❓          | ❓         | ❓
+Interrupts               | ✔️        | ✔️        | ✔️         | ❓          | ❓         | ✔️
 Analog input (ADC)       | ✔️        | ✔️        | ✔️         | ❓          | ❓         | ✔️
 `Wire` (I²C)             | ❌         | ❌         | ❗          | ❌          | ❌         | ❓
 `SPI`                    | ❌         | ❌         | ❌          | ❌          | ❌         | ❌


### PR DESCRIPTION
- all GPIOS can generate interrupts
- added calls to NVIC_SetPriority/NVIC_EnableIRQ/NVIC_DisableIRQ

I couldn't test detachInterrupt (where I added a call to NVIC_DisableIRQ) but attachInterruptParam now works.