### PR TITLE
[common] Automatically cleanup OTA context in begin()

### DIFF
--- a/cores/common/arduino/libraries/common/Update/Update.cpp
+++ b/cores/common/arduino/libraries/common/Update/Update.cpp
@@ -44,7 +44,6 @@ bool UpdateClass::begin(
 	if (this->ctx) {
 		LT_W("OTA context unclean!");
 		this->cleanup(true);
-		return false;
 	}
 	this->clearError();
 	if (size == 0) {


### PR DESCRIPTION
In case OTA is interrupted by the user, the ota-handling code in esphome does not call end(). Instead it will immediately call begin() again if the user restarts the ota, which would fail because of that. The esphome team insist that this is correct behavior on their behalf and libretiny ota backend needs to handle such cases gracefully.