### PR TITLE
[beken-72xx] Fix watchdog resets during WiFi connection

### DIFF
--- a/cores/beken-72xx/arduino/libraries/WiFi/WiFiSTA.cpp
+++ b/cores/beken-72xx/arduino/libraries/WiFi/WiFiSTA.cpp
@@ -1,6 +1,7 @@
 /* Copyright (c) Kuba Szczodrzyński 2022-06-27. */
 
 #include "WiFiPrivate.h"
+#include <libretiny.h>
 
 WiFiStatus WiFiClass::begin(
 	const char *ssid,
@@ -40,8 +41,14 @@ WiFiStatus WiFiClass::begin(
 		STA_CFG.wifi_mode			= BK_STATION;
 	}
 
-	if (reconnect(bssid))
+	// Feed watchdog before potentially long-blocking reconnect
+	lt_wdt_feed();
+
+	if (reconnect(bssid)) {
+		// Feed watchdog after reconnect
+		lt_wdt_feed();
 		return WL_CONNECTED;
+	}
 
 	return WL_CONNECT_FAILED;
 }


### PR DESCRIPTION
## Fix watchdog resets during WiFi connection on BK72xx

Add watchdog feeds before and after the blocking `reconnect()` call to prevent watchdog resets during WiFi connection.

### Why no scan optimization like RTL?

Unlike Realtek where we use `wifi_set_pscan_chan()` to limit scanning to the known channel, the BK72xx SDK doesn't expose a functional way to skip or limit the scan. The SDK has `fast_connect` infrastructure but:

- `wpa_s->fast_connect` field doesn't exist in the `wpa_supplicant_2_9` headers used by BK7231N
- `g_sta_param_ptr->fast_connect_set` is only checked when `!CFG_WPA_CTRL_IFACE`
- The channel parameter passed to `wlan_sta_connect()` is ignored

So for now, we just ensure the watchdog doesn't reset during the ~3.5s-7s connection time.
