### PR TITLE
[realtek-ambz2] Refactor OTA for better bootloader compatibility

### DIFF
--- a/builder/family/realtek-ambz2.py
+++ b/builder/family/realtek-ambz2.py
@@ -438,7 +438,9 @@ queue.BuildLibraries()
 image_part_table = "${BUILD_DIR}/image_part_table.${FLASH_PART_TABLE_OFFSET}.bin"
 image_bootloader = "${BUILD_DIR}/image_bootloader.${FLASH_BOOT_OFFSET}.bin"
 image_firmware_is = "${BUILD_DIR}/image_firmware_is.${FLASH_OTA1_OFFSET}.bin"
-part_firmware_is_header = "${BUILD_DIR}/part_firmware_is.header.${FLASH_OTA1_OFFSET}.bin"
+part_firmware_is_header = (
+    "${BUILD_DIR}/part_firmware_is.header.${FLASH_OTA1_OFFSET}.bin"
+)
 part_firmware_is_data = "${BUILD_DIR}/part_firmware_is.data.${FLASH_OTA1_OFFSET}.bin"
 env.Replace(
     # linker command (dual .bin outputs)

--- a/builder/family/realtek-ambz2.py
+++ b/builder/family/realtek-ambz2.py
@@ -438,15 +438,16 @@ queue.BuildLibraries()
 image_part_table = "${BUILD_DIR}/image_part_table.${FLASH_PART_TABLE_OFFSET}.bin"
 image_bootloader = "${BUILD_DIR}/image_bootloader.${FLASH_BOOT_OFFSET}.bin"
 image_firmware_is = "${BUILD_DIR}/image_firmware_is.${FLASH_OTA1_OFFSET}.bin"
+part_firmware_is_header = "${BUILD_DIR}/part_firmware_is.header.${FLASH_OTA1_OFFSET}.bin"
+part_firmware_is_data = "${BUILD_DIR}/part_firmware_is.data.${FLASH_OTA1_OFFSET}.bin"
 env.Replace(
     # linker command (dual .bin outputs)
     LINK='${LTCHIPTOOL} link2bin ${BOARD_JSON} "" ""',
     # UF2OTA input list
     UF2OTA=[
-        # use unmodified image for flasher
-        f"{image_firmware_is},{image_firmware_is}=flasher:ota1,ota2",
-        # use same image for device OTA
-        f"{image_firmware_is},{image_firmware_is}=device:ota1,ota2",
+        # use the same image for flasher and device, but flash the 1st sector last
+        f"{part_firmware_is_data},{part_firmware_is_data}=device:ota1,ota2;flasher:ota1,ota2",
+        f"{part_firmware_is_header},{part_firmware_is_header}=device:ota1,ota2;flasher:ota1,ota2",
         # having flashed an application image, update the bootloader and partition table (incl. keys)
         f"{image_bootloader},{image_bootloader}=flasher:boot,boot",
         f"{image_part_table},{image_part_table}=flasher:part_table,part_table",

--- a/builder/main.py
+++ b/builder/main.py
@@ -18,7 +18,7 @@ platform: PlatformBase = env.PioPlatform()
 board: PlatformBoardConfig = env.BoardConfig()
 
 python_deps = {
-    "ltchiptool": ">=4.12.2,<5.0",
+    "ltchiptool": ">=4.13.0,<5.0",
 }
 env.SConscript("python-venv.py", exports="env")
 env.ConfigurePythonVenv()

--- a/cores/common/base/api/lt_utils.h
+++ b/cores/common/base/api/lt_utils.h
@@ -18,6 +18,13 @@
 		_a < _b ? _a : _b;      \
 	})
 
+#define LT_MEM32(addr) (*((volatile uint32_t *)(addr)))
+
+// from https://scaryreasoner.wordpress.com/2009/02/28/checking-sizeof-at-compile-time/
+// (include/linux/kernel.h)
+#define LT_BUILD_BUG_ON(condition) ((void)sizeof(char[1 - 2 * !!(condition)]))
+#define LT_BUILD_CHECK(condition)  ((void)sizeof(char[1 - 2 * !(condition)]))
+
 /**
  * @brief Generate random bytes using rand().
  *

--- a/cores/realtek-amb/base/api/lt_ota.c
+++ b/cores/realtek-amb/base/api/lt_ota.c
@@ -1,0 +1,75 @@
+/* Copyright (c) Kuba Szczodrzyński 2026-02-01. */
+
+#include <libretiny.h>
+#include <sdk_private.h>
+
+#define SYSTEM_DATA_LENGTH 128
+
+/**
+ * Convert OTA index (1, 2) into partition offset.
+ */
+bool lt_ota_dual_get_offset(uint8_t index, uint32_t *offset) {
+	switch (index) {
+		case 1:
+			*offset = FLASH_OTA1_OFFSET;
+			break;
+		case 2:
+			*offset = FLASH_OTA2_OFFSET;
+			break;
+		default:
+			return false;
+	}
+	return true;
+}
+
+/**
+ * Check which OTA image is active using the bit flag method.
+ */
+uint8_t lt_ota_dual_get_stored_by_flag() {
+	// find first non-zero bit of the flag in system data:
+	// - even count of zero-bits means OTA1, odd count means OTA2
+	//   this allows to switch OTA images by simply clearing next bits,
+	//   without needing to erase the flash
+	uint32_t ota_counter = LT_MEM32(SPI_FLASH_BASE + FLASH_SYSTEM_OFFSET + 4);
+	uint8_t bitidx;
+	for (bitidx = 0; bitidx < 32; bitidx++) {
+		if (ota_counter & (1 << bitidx))
+			break;
+	}
+	return 1 + (bitidx & 1);
+}
+
+/**
+ * Flip the OTA selection bit flag switch.
+ */
+bool lt_ota_dual_switch_flag() {
+	uint32_t bit_flag = LT_MEM32(SPI_FLASH_BASE + FLASH_SYSTEM_OFFSET + 4);
+
+	if (bit_flag == 0) {
+		// allocate memory and read old system data contents
+		uint32_t *system = malloc(SYSTEM_DATA_LENGTH);
+		if (!system)
+			return false;
+		if (lt_flash_read(FLASH_SYSTEM_OFFSET, (void *)system, SYSTEM_DATA_LENGTH) != SYSTEM_DATA_LENGTH)
+			goto err;
+
+		// set bit flag to OTA 2
+		system[1] = 0xFFFFFFFE;
+
+		// erase and write
+		if (!lt_flash_erase_block(FLASH_SYSTEM_OFFSET))
+			goto err;
+		if (lt_flash_write(FLASH_SYSTEM_OFFSET, (void *)system, SYSTEM_DATA_LENGTH) != SYSTEM_DATA_LENGTH)
+			goto err;
+
+		free(system);
+		return true;
+	err:
+		free(system);
+		return false;
+	}
+
+	// shift the bit flag and write without erasing
+	bit_flag <<= 1;
+	return lt_flash_write(FLASH_SYSTEM_OFFSET + 4, (void *)&bit_flag, 4) == 4;
+}

--- a/cores/realtek-ambz2/base/api/lt_ota.c
+++ b/cores/realtek-ambz2/base/api/lt_ota.c
@@ -3,92 +3,111 @@
 #include <libretiny.h>
 #include <sdk_private.h>
 
-#include <device_lock.h>
-#include <osdep_service.h>
-
-// from SDK
-extern uint32_t sys_update_ota_get_curr_fw_idx(void);
+// private utilities from realtek-amb core
+extern bool lt_ota_dual_get_offset(uint8_t index, uint32_t *offset);
+extern uint8_t lt_ota_dual_get_stored_by_flag();
+extern bool lt_ota_dual_switch_flag();
 
 #define FLASH_SECTOR_SIZE		0x1000
-#define IMAGE_PUBLIC_KEY_OFFSET 32
-#define IMAGE_PUBLIC_KEY_LENGTH 32
+#define IMAGE_PUBLIC_KEY_OFFSET 0x20
+#define IMAGE_TYPE_OFFSET		0xE8
+#define IMAGE_TYPE_VALUE		0x02 // FWHS_S
+#define IMAGE_SERIAL_OFFSET		0xF4
+
+typedef enum {
+	LT_OTA_SWITCH_SERIAL_NUMBER = 1,
+	LT_OTA_SWITCH_BIT_FLAG		= 2,
+} lt_ota_switch_type_t;
 
 // IMAGE_PUBLIC_KEY is defined by build script without braces to avoid shell escaping issues
 static const uint8_t lt_image_public_key[] = {IMAGE_PUBLIC_KEY};
 
-typedef enum {
-	INVALID	 = 0,
-	DISABLED = 1,
-	ENABLED	 = 2,
-} lt_ota_image_state_t;
+static lt_ota_switch_type_t ota_switch_type = 0;
 
-static bool lt_ota_get_image_offset(uint8_t index, uint32_t *offset) {
-	switch (index) {
-		case 1:
-			*offset = FLASH_OTA1_OFFSET;
-			break;
-		case 2:
-			*offset = FLASH_OTA2_OFFSET;
-			break;
-		default:
-			return false;
+/**
+ * Scan the bootloader code to check the OTA switch method (bit flag or serial number).
+ */
+lt_ota_switch_type_t lt_ota_check_switch_type() {
+	if (ota_switch_type)
+		return ota_switch_type;
+
+	for (uint32_t pos = 0; pos < FLASH_BOOT_LENGTH; pos++) {
+		// if the bootloader contains the string, it uses a bit flag for switching OTA images
+		uint8_t *data = (void *)(SPI_FLASH_BASE + FLASH_BOOT_OFFSET + pos);
+		if (memcmp(data, "fw1 USE", 7) == 0)
+			return (ota_switch_type = LT_OTA_SWITCH_BIT_FLAG);
 	}
-	return true;
+	return (ota_switch_type = LT_OTA_SWITCH_SERIAL_NUMBER);
 }
 
-static uint8_t lt_ota_get_other_index(uint8_t index) {
-	return index ^ 0b11; // 1 -> 2, 2 -> 1
+/**
+ * Check which OTA image is active using the serial number method.
+ */
+uint8_t lt_ota_dual_get_stored_by_sn() {
+	// choose the one with a higher serial number
+	// SN is always at offset 0xF4 into the OTA image
+	uint32_t ota1_sn = LT_MEM32(SPI_FLASH_BASE + FLASH_OTA1_OFFSET + IMAGE_SERIAL_OFFSET);
+	uint32_t ota2_sn = LT_MEM32(SPI_FLASH_BASE + FLASH_OTA2_OFFSET + IMAGE_SERIAL_OFFSET);
+	if (ota2_sn > ota1_sn)
+		return 2;
+	return 1;
 }
 
-static lt_ota_image_state_t lt_ota_get_image_state(uint8_t index) {
+/**
+ * Make the image invalid, if it isn't already.
+ */
+bool lt_ota_image_invalidate(uint32_t index) {
+	if (!lt_ota_is_valid(index))
+		return true;
 	uint32_t offset;
-	if (!lt_ota_get_image_offset(index, &offset))
-		return INVALID;
-
-	uint8_t public_key[IMAGE_PUBLIC_KEY_LENGTH];
-	uint32_t num_read = lt_flash_read(offset + IMAGE_PUBLIC_KEY_OFFSET, public_key, sizeof(public_key));
-	if (num_read != sizeof(public_key))
-		return INVALID;
-
-	if (memcmp(public_key, lt_image_public_key, sizeof(public_key)) == 0)
-		return ENABLED;
-
-	public_key[0] = ~(public_key[0]);
-	if (memcmp(public_key, lt_image_public_key, sizeof(public_key)) == 0)
-		return DISABLED;
-
-	return INVALID;
-}
-
-static bool lt_ota_set_image_enabled(uint8_t index, bool new_enabled) {
-	uint32_t offset;
-	if (!lt_ota_get_image_offset(index, &offset))
+	if (!lt_ota_dual_get_offset(index, &offset))
 		return false;
 
-	_irqL irqL;
-	uint8_t *header = (uint8_t *)malloc(FLASH_SECTOR_SIZE);
+	// read 32 bits at 0xE8 - points to image type (in image header)
+	// - that byte is known to be 0x02, so it can be restored in lt_ota_image_revalidate()
+	// - the image header is used during OTA hash calculation, unlike the public key
+	uint32_t header_flags = LT_MEM32(SPI_FLASH_BASE + offset + IMAGE_TYPE_OFFSET);
+	// zero-out the 1st byte (little-endian)
+	header_flags &= ~0xFF;
+	// write back to flash (erase not needed)
+	return lt_flash_write(offset + IMAGE_TYPE_OFFSET, (void *)&header_flags, 4) == 4;
+}
 
-	rtw_enter_critical(NULL, &irqL);
-	device_mutex_lock(RT_DEV_LOCK_FLASH);
-	flash_stream_read(&lt_flash_obj, offset, FLASH_SECTOR_SIZE, header);
+/**
+ * Make the image valid again, if it isn't already.
+ * Only works if the image was invalidated using `lt_ota_image_invalidate()`.
+ */
+bool lt_ota_image_revalidate(uint32_t index) {
+	if (lt_ota_is_valid(index))
+		return true;
+	uint32_t offset;
+	if (!lt_ota_dual_get_offset(index, &offset))
+		return false;
 
-	bool enabled = header[IMAGE_PUBLIC_KEY_OFFSET] == lt_image_public_key[0];
-	if (enabled != new_enabled) {
-		// negate first byte of OTA signature
-		header[0] = ~(header[0]);
-		// negate first byte of public key
-		header[IMAGE_PUBLIC_KEY_OFFSET] = ~(header[IMAGE_PUBLIC_KEY_OFFSET]);
+	// read the entire sector (required for erase/write cycle)
+	uint8_t *header = malloc(FLASH_SECTOR_SIZE);
+	if (!header)
+		return false;
+	lt_flash_read(offset, header, FLASH_SECTOR_SIZE);
 
-		// write to flash
-		hal_flash_sector_erase(lt_flash_obj.phal_spic_adaptor, offset);
-		hal_flash_burst_write(lt_flash_obj.phal_spic_adaptor, FLASH_SECTOR_SIZE, offset, header);
-	}
+	// make sure the image type is currently 0x00
+	if (header[IMAGE_TYPE_OFFSET] != 0x00)
+		goto err;
 
-	device_mutex_unlock(RT_DEV_LOCK_FLASH);
-	rtw_exit_critical(NULL, &irqL);
+	// set the image type back to 0x02
+	header[IMAGE_TYPE_OFFSET] = IMAGE_TYPE_VALUE;
+
+	// erase the sector and write it back (with a restored image type)
+	if (!lt_flash_erase_block(offset))
+		goto err;
+	if (lt_flash_write(offset, header, FLASH_SECTOR_SIZE) != FLASH_SECTOR_SIZE)
+		goto err;
+
 	free(header);
-
 	return true;
+err:
+	free(header);
+	return false;
 }
 
 // public interface implementation
@@ -98,37 +117,73 @@ lt_ota_type_t lt_ota_get_type() {
 }
 
 bool lt_ota_is_valid(uint8_t index) {
-	return lt_ota_get_image_state(index) != INVALID;
+	uint32_t offset;
+	if (!lt_ota_dual_get_offset(index, &offset))
+		return false;
+
+	// check the public key
+	uint8_t *public_key = (void *)(SPI_FLASH_BASE + offset + IMAGE_PUBLIC_KEY_OFFSET);
+	if (memcmp(public_key, lt_image_public_key, sizeof(lt_image_public_key)) != 0)
+		return false;
+
+	// check the image type
+	if ((LT_MEM32(SPI_FLASH_BASE + offset + IMAGE_TYPE_OFFSET) & 0xFF) != IMAGE_TYPE_VALUE)
+		return false;
+	return true;
 }
 
 uint8_t lt_ota_dual_get_current() {
 	// ambz2 uses virtual memory, so we can't use function address to determine active image
-	// use the SDK instead
-	return sys_update_ota_get_curr_fw_idx();
+	// use the bootloader-exported boot info instead
+	fw_img_export_info_type_t *info = hal_flash_boot_stubs.fw_img_info_tbl_query();
+	return info->loaded_fw_idx;
 }
 
 uint8_t lt_ota_dual_get_stored() {
-	// bootloader prioritizes FW1 if both are valid
-	return lt_ota_get_image_state(1) == ENABLED ? 1 : 2;
+	bool ota1_valid = lt_ota_is_valid(1);
+	bool ota2_valid = lt_ota_is_valid(2);
+
+	// if both images are invalid, assume the current one is somehow still bootable
+	if (!ota1_valid && !ota2_valid)
+		return lt_ota_dual_get_current();
+
+	// if one image is invalid, return the valid one
+	if (!ota1_valid)
+		return 2;
+	if (!ota2_valid)
+		return 1;
+
+	// if both images seem valid - guess the bootloader's choice
+	switch (lt_ota_check_switch_type()) {
+		case LT_OTA_SWITCH_SERIAL_NUMBER:
+			return lt_ota_dual_get_stored_by_sn();
+		case LT_OTA_SWITCH_BIT_FLAG:
+			return lt_ota_dual_get_stored_by_flag();
+		default:
+			return 1;
+	}
 }
 
 bool lt_ota_switch(bool revert) {
 	uint8_t current = lt_ota_dual_get_current();
-	uint8_t stored	= lt_ota_dual_get_stored();
-	if ((current == stored) == revert)
-		return true;
+	uint8_t target	= current ^ 0b11;
 
-	uint8_t to_enable  = lt_ota_get_other_index(stored);
-	uint8_t to_disable = stored;
-
-	if (!lt_ota_is_valid(to_enable))
-		return false;
+	uint8_t to_enable  = revert ? current : target;
+	uint8_t to_disable = revert ? target : current;
 
 	// enable first, so there is always at least one enabled image
-	if (!lt_ota_set_image_enabled(to_enable, true))
+	if (!lt_ota_image_revalidate(to_enable))
 		return false;
-	if (!lt_ota_set_image_enabled(to_disable, false))
+	// make sure it's valid after (possibly) re-validating
+	if (!lt_ota_is_valid(to_enable))
 		return false;
+	// finally, invalidate the other one
+	lt_ota_image_invalidate(to_disable);
+
+	// additionally, adjust the bit flag
+	uint8_t stored_flag = lt_ota_dual_get_stored_by_flag();
+	if (stored_flag != to_enable)
+		lt_ota_dual_switch_flag();
 
 	return true;
 }

--- a/cores/realtek-ambz2/base/sdk_extern.h
+++ b/cores/realtek-ambz2/base/sdk_extern.h
@@ -23,6 +23,31 @@ uint32_t efuse_OneByteRead(uint32_t x33300000, uint32_t addr, uint8_t *buf, uint
 uint32_t EFUSERead8(uint32_t x33300000, uint32_t addr, uint8_t *buf, uint32_t ldo);
 uint32_t hal_get_chip_id(uint32_t *id);
 
+// bootloader exported info
+typedef struct fw_img_export_info_type_s {
+	uint32_t img1_start_offset;
+	uint32_t fw1_start_offset;
+	uint32_t fw2_start_offset;
+	uint32_t fw1_sn;
+	uint32_t fw2_sn;
+	uint8_t fw1_valid;
+	uint8_t fw2_valid;
+	uint8_t loaded_fw_idx;
+} fw_img_export_info_type_t;
+
+// ROM stubs at 0x770
+typedef struct hal_flash_boot_stubs_s {
+	void *ppartition_tbl;
+	void *(*get_fw1_key_tbl)();
+	void *(*get_fw2_key_tbl)();
+	void (*clear_export_partition_tbl)();
+	void (*erase_boot_loader)();
+	fw_img_export_info_type_t *(*fw_img_info_tbl_query)();
+	int32_t (*otu_fw_download)(hal_uart_adapter_t *potu_uart, uint32_t flash_sel, uint32_t flash_offset);
+} hal_flash_boot_stubs_t;
+
+extern const hal_flash_boot_stubs_t hal_flash_boot_stubs;
+
 #ifdef __cplusplus
 } // extern "C"
 #endif


### PR DESCRIPTION
This PR makes it possible to use OTA updates on RTL8720CF, regardless of the type of bootloader installed (Realtek or Tuya).

The method used here is largely inspired by @prokoma's original idea of invalidating "the other image". However, instead of negating one byte of the header (which requires a flash erase every time), a certain chosen byte is zeroed-out.

This method doesn't require an erase when invalidating an image (i.e. "activating" the OTA update). Only when re-validating such image (i.e. reverting before reboot, or rolling back after reboot) a flash erase is needed. Those are extremely rare situations; in fact, I don't think any of the custom projects use this feature.

The `stored` image detection is crucial for correct OTA activation - this didn't work in previous iterations of the OTA support code.
The updated method includes scanning the bootloader's code on runtime, in order to determine which kind is installed.
The Tuya bootloader always has a `fw1 USE` string, which makes the detection easy.

The two bootloaders differ by the method used to select an image to boot.
- Realtek compares serial numbers exclusively - chooses the one that's greater, or image 1 if they're equal.
- Tuya doesn't care about serial numbers and uses the "bit flag" method (`system` partition, just like AmebaZ).
- Both bootloaders check image validity - the hash of the image header (96 bytes at 0xE0) must match the one written at 0x0. That's the only performed check; the public key is not compared.

During image invalidation, the chosen erased byte is "image type". It is known to always be at 0xE8, and always have a value of 0x02, which means `FWHS_S`. That makes it easy to restore the corrupted byte later, if necessary.

Invalidating the image is enough to make it work on both bootloader types. However, as a safety measure, the `system` partition bit flag is also adjusted to reflect the correct `target` image after applying an update.

Several functions have also been moved from `realtek-ambz` to common code, since they are applicable for both families.

EDIT: To make updates safe against power outages (where a partial image could be written, and used by the bootloader after next reboot), the image header is erased first, and written last. Throughout the entire process, the header is not there, so even if the device crashes, the bootloader won't boot it. This doesn't require any device-side changes, however `ltchiptool` must be updated to 4.13.0 to be able to flash this new image.

---

I'm also tagging @bdraco - you've taken part in the OTA testing process, so it would be greatly appreciated if you could also test this PR.

I tested that several times on RTL8720CF and CM, both on Tuya and Realtek bootloaders, and with different versions of those. Each time it worked just fine, however it's true what they say - "it works on my machine".