### PR TITLE
Changes for new ambz2 sdk

### DIFF
--- a/builder/family/realtek-ambz2.py
+++ b/builder/family/realtek-ambz2.py
@@ -202,6 +202,9 @@ queue.AddLibrary(
             "-Wno-return-type",
             "-Wno-unused-variable",
         ],
+        LINKFLAGS=[
+            "-nostartfiles",
+        ]
     ),
 )
 
@@ -297,7 +300,7 @@ queue.AddLibrary(
     ],
     includes=[
         "+<.>",
-        "+<board/amebaz2/lib>",
+        "+<board/amebaz2/lib/GCC>",
         "+<board/amebaz2/src/data_uart>",
         "+<board/amebaz2/src/hci>",
         "+<board/amebaz2/src/os>",
@@ -386,7 +389,7 @@ queue.AppendPublic(
         # fmt: off
         join(COMPONENT_DIR, "soc", "realtek", "8710c", "misc", "bsp", "lib", "common", "GCC"),
         join(COMPONENT_DIR, "soc", "realtek", "8710c", "fwlib", "lib", "lib"),
-        join(COMPONENT_DIR, "common", "bluetooth", "realtek", "sdk", "board", "amebaz2", "lib"),
+        join(COMPONENT_DIR, "common", "bluetooth", "realtek", "sdk", "board", "amebaz2", "lib", "GCC"),
         join(COMPONENT_DIR, "soc", "realtek", "8710c", "misc", "bsp", "ROM"),
         # fmt: on
     ],
@@ -396,7 +399,6 @@ queue.AppendPublic(
         "_http",
         "_dct",
         "_eap",
-        "_p2p",
         "_websocket",
         "_wps",
         "m",

--- a/cores/realtek-amb/arduino/libraries/WiFi/WiFiGeneric.cpp
+++ b/cores/realtek-amb/arduino/libraries/WiFi/WiFiGeneric.cpp
@@ -219,9 +219,10 @@ bool WiFiClass::setTxPower(int power) {
 
 int WiFiClass::getTxPower() {
 	return 0;
-	int power = 0;
-	wifi_get_txpower(&power);
-	return power;
+	// not implemented in realtek SDK
+	// int power = 0;
+	// wifi_get_txpower(&power);
+	// return power;
 }
 
 IPAddress WiFiClass::hostByName(const char *hostname) {

--- a/cores/realtek-amb/arduino/libraries/WiFi/WiFiPrivate.h
+++ b/cores/realtek-amb/arduino/libraries/WiFi/WiFiPrivate.h
@@ -33,9 +33,9 @@ extern void dns_server_deinit(void);
 // wifi_util.c
 #if !LT_RTL8720C
 extern void rltk_stop_softap(const char *ifname);
-#endif
 extern void rltk_suspend_softap(const char *ifname);
 extern void rltk_suspend_softap_beacon(const char *ifname);
+#endif
 
 } // extern "C"
 


### PR DESCRIPTION
I was able to compile and succesfully run esphome build with newer amebaz2.
This PR contain changes I had to do in libretiny to make this compile.

Note that my test was very basic - I only checked that esphome was started and has connected to wifi.

The SDK i used was this: https://github.com/Ameba-AIoT/ameba-rtos-z2 (commit b758282b80e2435d539ef75e57330eca92964067).

On the first glance there seem to be a lot of differences between this and the old sdk that libretiny currently uses. But the quick comparison shows that most of them are due to changed formatting, added code comments and some quality improvements. I did see also a bugfix related to flash unlocking, and also added support for more wifi security types, so switching to this version might actually be be worth it.