### PR TITLE
[realtek-amb] Reduce main task stack from 16KB to 8KB

### DIFF
--- a/cores/realtek-amb/arduino/src/main.cpp
+++ b/cores/realtek-amb/arduino/src/main.cpp
@@ -14,7 +14,7 @@ void lt_init_arduino() {
 #endif
 
 bool startMainTask() {
-	osThreadDef(mainTask, osPriorityRealtime, 1, 4096 * 4);
+	osThreadDef(mainTask, osPriorityRealtime, 1, 8192);
 	main_tid = osThreadCreate(osThread(mainTask), NULL);
 	osKernelStart();
 	return true;


### PR DESCRIPTION
The main task stack is set to `4096 * 4` = 16384 bytes. Runtime profiling with FreeRTOS stack watermark scanning shows only ~1.3KB is actually used, wasting ~8KB of RAM on all Realtek families (amb, ambz, ambz2) that inherit this startup code.

Reduce to 8192 bytes, which matches BK72xx and LN882H, and still leaves ~6.4KB of headroom. This is the same value ESPHome uses for ESP32