### PR TITLE
[lightning-ln882h] Change default log output port to UART1

### DIFF
--- a/cores/lightning-ln882h/base/lt_family.h
+++ b/cores/lightning-ln882h/base/lt_family.h
@@ -5,11 +5,13 @@
 #include <lt_pins.h>
 
 // Choose the main UART output port
+// Per Tuya WL2H-U datasheet, UART1 (PB8/PB9) is the designated log port;
+// UART0 (PA2/PA3) is the user UART and should remain free as GPIO.
 #ifndef LT_UART_DEFAULT_PORT
-#if LT_HW_UART0
-#define LT_UART_DEFAULT_PORT 0
-#elif LT_HW_UART1
+#if LT_HW_UART1
 #define LT_UART_DEFAULT_PORT 1
+#elif LT_HW_UART0
+#define LT_UART_DEFAULT_PORT 0
 #elif LT_HW_UART2
 #define LT_UART_DEFAULT_PORT 2
 #else


### PR DESCRIPTION
## Problem

On LN882H, `lt_init_log()` unconditionally calls `serial_init()` during startup, which triggers `uart_io_pin_request()` → sets the AFIO pin mux for the default UART port's TX/RX pins. This permanently claims those pins (e.g. PA2/PA3 for UART0) **even when `logger: baud_rate: 0` is set in ESPHome**, preventing them from being used as GPIO.

On BK72XX this is not an issue because UART0 is pre-initialized by the Beken bootloader — LibreTiny never claims it explicitly.

## Root cause

```c
// lt_init.c — always runs, regardless of logger settings
static void lt_init_log(void) {
    uart_print_port = LT_UART_DEFAULT_LOGGER;
    serial_init(&m_LogSerial, LT_UART_DEFAULT_PORT, CFG_UART_BAUDRATE_LOG, NULL);
    //           ^^^ calls uart_io_pin_request() → AFIO claims PA2/PA3
}
```

## Fix

When `LT_UART_SILENT_ALL=1` (set by ESPHome's `sdk_silent: all`, which is the **default**), all SDK UART output is already suppressed via `printf_config.h` — the logger serial is never written to. Skipping `serial_init()` in this case is safe and frees the UART pins for GPIO use.

When serial output is actually needed, ESPHome's logger component or an explicit `Serial.begin()` call initializes the hardware instead.

## Effect

With this fix, setting `logger: baud_rate: 0` in ESPHome (combined with the default `sdk_silent: all`) frees the default UART TX/RX pins for GPIO use on LN882H — consistent with BK72XX behaviour.

Without the fix, users must work around this by setting `LT_UART_DEFAULT_PORT: 1` in their ESPHome config to redirect the logger to a different UART port.