### PR TITLE
[lightning-ln882h] Add static IP support

### DIFF
--- a/builder/family/lightning-ln882h.py
+++ b/builder/family/lightning-ln882h.py
@@ -32,7 +32,9 @@ queue.AppendPublic(
         "-Wno-write-strings",
         "-Wno-maybe-uninitialized",
     ],
-    CXXFLAGS=[],
+    CXXFLAGS=[
+        "-Wno-register",  # cmb_def.h uses 'register' keyword (removed in C++17)
+    ],
     CPPDEFINES=[
         # other options
         "ARM_MATH_CM4",

--- a/cores/lightning-ln882h/arduino/libraries/WiFi/WiFiEvents.cpp
+++ b/cores/lightning-ln882h/arduino/libraries/WiFi/WiFiEvents.cpp
@@ -28,6 +28,22 @@ static void wifiEventStaConnected(void *arg) {
 	memcpy(eventInfo.wifi_sta_connected.bssid, pWiFi->BSSID(), 6);
 
 	pWiFi->postEvent(ARDUINO_EVENT_WIFI_STA_CONNECTED, eventInfo);
+
+	// If static IP is configured, apply it now and stop DHCP before the SDK
+	// starts it. wifi_sta_connect() always starts DHCP internally; we have no
+	// way to pass dhcp_mode to it (unlike BK72XX's bk_wlan_start_sta_adv_fix).
+	WiFiNetworkInfo &info = pDATA->sta;
+	if (info.localIP) {
+		struct netif *ifs = netdev_get_netif(NETIF_IDX_STA);
+		ip4_addr_t ipaddr, netmask, gw;
+		ipaddr.addr	 = info.localIP;
+		netmask.addr = info.subnet;
+		gw.addr		 = info.gateway;
+		netif_set_addr(ifs, &ipaddr, &netmask, &gw);
+		netifapi_dhcp_release_and_stop(ifs);
+		// Emit GOT_IP manually — DHCP is stopped so the netdev callback won't fire
+		wifiEventIpReceived(ifs);
+	}
 }
 
 static void wifiEventStaDisconnected(void *arg) {

--- a/cores/lightning-ln882h/arduino/libraries/WiFi/WiFiEvents.cpp
+++ b/cores/lightning-ln882h/arduino/libraries/WiFi/WiFiEvents.cpp
@@ -1,8 +1,47 @@
 /* Copyright (c) Etienne Le Cousin 2024-03-10. */
 
 #include "WiFiPrivate.h"
+#include <lwip/dhcp.h>  // dhcp_supplied_address, dhcp_release_and_stop
+#include <lwip/tcpip.h> // tcpip_callback
 
 static void wifiEventIpReceived(struct netif *nif);
+
+// ---------------------------------------------------------------------------
+// Async callback: scheduled via tcpip_callback() from within wifiEventIpReceived
+// when DHCP completes despite our best-effort stop in wifiEventStaConnected().
+//
+// Runs in the LwIP tcpip_thread AFTER dhcp_recv() has fully returned, so it
+// is safe to call dhcp_release_and_stop() directly here (no use-after-free).
+// We must NOT use netifapi_dhcp_release_and_stop() here — that function posts
+// a message to the tcpip_thread mailbox and waits for completion, which would
+// deadlock since we ARE the tcpip_thread.
+// ---------------------------------------------------------------------------
+static void wifiApplyStaticIpCallback(void *arg) {
+	struct netif *nif = (struct netif *)arg;
+	if (!pWiFi || !nif)
+		return;
+	WiFiNetworkInfo &info = pDATA->sta;
+	if (!info.localIP)
+		return;
+
+	// Stop DHCP — safe here, we're outside dhcp_recv()
+	dhcp_release_and_stop(nif);
+
+	// Apply the configured static address
+	ip4_addr_t ipaddr, netmask, gw;
+	ipaddr.addr  = info.localIP;
+	netmask.addr = info.subnet;
+	gw.addr		 = info.gateway;
+	netif_set_addr(nif, &ipaddr, &netmask, &gw);
+	// netif_set_addr triggers the netif status callback again, but since DHCP
+	// is now stopped dhcp_supplied_address() returns false, so g_get_ip_cb is
+	// NOT re-entered — no infinite recursion.
+
+	// Emit GOT_IP with the correct static address
+	wifiEventIpReceived(nif);
+}
+
+// ---------------------------------------------------------------------------
 
 void wifiEventSendArduino(EventId event) {
 	EventInfo eventInfo;
@@ -34,6 +73,12 @@ static void wifiEventStaConnected(void *arg) {
 	// If static IP is configured, apply it now and stop DHCP before the SDK
 	// starts it. wifi_sta_connect() always starts DHCP internally; we have no
 	// way to pass dhcp_mode to it (unlike BK72XX's bk_wlan_start_sta_adv_fix).
+	//
+	// IMPORTANT: stop DHCP *before* calling netif_set_addr. If DHCP is already
+	// BOUND when this event fires, netif_set_addr would trigger the netif status
+	// callback with dhcp_supplied_address==true, which would schedule an
+	// unnecessary wifiApplyStaticIpCallback. Stopping DHCP first ensures the
+	// status callback sees dhcp_supplied_address==false and stays silent.
 	WiFiNetworkInfo &info = pDATA->sta;
 	if (info.localIP) {
 		struct netif *ifs = netdev_get_netif(NETIF_IDX_STA);
@@ -41,8 +86,8 @@ static void wifiEventStaConnected(void *arg) {
 		ipaddr.addr	 = info.localIP;
 		netmask.addr = info.subnet;
 		gw.addr		 = info.gateway;
+		netifapi_dhcp_release_and_stop(ifs); // Stop first — safe (wifi_manager task)
 		netif_set_addr(ifs, &ipaddr, &netmask, &gw);
-		netifapi_dhcp_release_and_stop(ifs);
 		// Emit GOT_IP manually — DHCP is stopped so the netdev callback won't fire
 		wifiEventIpReceived(ifs);
 	}
@@ -117,6 +162,33 @@ static void wifiEventIpReceived(struct netif *nif) {
 	memset(&eventInfo, 0, sizeof(EventInfo));
 	if (!pWiFi || !nif)
 		return; // failsafe
+
+	// Fallback: DHCP completed and assigned an address despite our attempt to
+	// stop it in wifiEventStaConnected(). This can happen when:
+	//   (a) WIFI_MGR_EVENT_STA_CONNECTED fires before the SDK starts DHCP, so
+	//       netifapi_dhcp_release_and_stop() was a NOP and DHCP ran afterward; or
+	//   (b) a reconnect/roam caused the SDK to restart DHCP without triggering
+	//       WIFI_MGR_EVENT_STA_CONNECTED again (e.g. SDK-internal auto-reconnect).
+	//
+	// In this case we are being called from sta_netif_status_changed_cb(), which
+	// is the LwIP netif status callback invoked from within dhcp_recv() in the
+	// tcpip_thread.  Two important constraints apply:
+	//   - Cannot call dhcp_release_and_stop() directly: dhcp_recv() hasn't
+	//     returned yet, freeing the dhcp struct now would be a use-after-free.
+	//   - Cannot call netifapi_dhcp_release_and_stop(): it posts a message to
+	//     the tcpip_thread mailbox and waits for a reply — deadlock because we
+	//     ARE the tcpip_thread.
+	//
+	// Solution: schedule wifiApplyStaticIpCallback via tcpip_callback(). It will
+	// run in the tcpip_thread after the current message (dhcp_recv) has returned,
+	// so neither constraint applies there.
+	WiFiNetworkInfo &info = pDATA->sta;
+	if (info.localIP && dhcp_supplied_address(nif)) {
+		tcpip_callback(wifiApplyStaticIpCallback, nif);
+		// Do not emit GOT_IP here with the wrong DHCP address.
+		// wifiApplyStaticIpCallback will emit it with the static address.
+		return;
+	}
 
 	eventInfo.got_ip.if_index			  = 0;
 	eventInfo.got_ip.ip_changed			  = true;

--- a/cores/lightning-ln882h/arduino/libraries/WiFi/WiFiEvents.cpp
+++ b/cores/lightning-ln882h/arduino/libraries/WiFi/WiFiEvents.cpp
@@ -2,6 +2,8 @@
 
 #include "WiFiPrivate.h"
 
+static void wifiEventIpReceived(struct netif *nif);
+
 void wifiEventSendArduino(EventId event) {
 	EventInfo eventInfo;
 	memset(&eventInfo, 0, sizeof(EventInfo));

--- a/cores/lightning-ln882h/arduino/libraries/WiFi/WiFiEvents.cpp
+++ b/cores/lightning-ln882h/arduino/libraries/WiFi/WiFiEvents.cpp
@@ -37,6 +37,16 @@ static void wifiApplyStaticIpCallback(void *arg) {
 	// is now stopped dhcp_supplied_address() returns false, so g_get_ip_cb is
 	// NOT re-entered — no infinite recursion.
 
+	// Restore configured DNS servers — DHCP may have overwritten them via option 6
+	// before we could stop it (reconnect/roam fallback path only).
+	ip4_addr_t d1, d2;
+	d1.addr = info.dns1;
+	d2.addr = info.dns2;
+	if (d1.addr)
+		dns_setserver(0, &d1);
+	if (d2.addr)
+		dns_setserver(1, &d2);
+
 	// Emit GOT_IP with the correct static address
 	wifiEventIpReceived(nif);
 }

--- a/cores/lightning-ln882h/arduino/libraries/WiFi/WiFiEvents.cpp
+++ b/cores/lightning-ln882h/arduino/libraries/WiFi/WiFiEvents.cpp
@@ -1,6 +1,57 @@
 /* Copyright (c) Etienne Le Cousin 2024-03-10. */
 
 #include "WiFiPrivate.h"
+#include <lwip/dhcp.h>	// dhcp_supplied_address, dhcp_release_and_stop
+#include <lwip/tcpip.h> // tcpip_callback
+
+static void wifiEventIpReceived(struct netif *nif);
+
+// ---------------------------------------------------------------------------
+// Async callback: scheduled via tcpip_callback() from within wifiEventIpReceived
+// when DHCP completes despite our best-effort stop in wifiEventStaConnected().
+//
+// Runs in the LwIP tcpip_thread AFTER dhcp_recv() has fully returned, so it
+// is safe to call dhcp_release_and_stop() directly here (no use-after-free).
+// We must NOT use netifapi_dhcp_release_and_stop() here — that function posts
+// a message to the tcpip_thread mailbox and waits for completion, which would
+// deadlock since we ARE the tcpip_thread.
+// ---------------------------------------------------------------------------
+static void wifiApplyStaticIpCallback(void *arg) {
+	struct netif *nif = (struct netif *)arg;
+	if (!pWiFi || !nif)
+		return;
+	WiFiNetworkInfo &info = pDATA->sta;
+	if (!info.localIP)
+		return;
+
+	// Stop DHCP — safe here, we're outside dhcp_recv()
+	dhcp_release_and_stop(nif);
+
+	// Apply the configured static address
+	ip4_addr_t ipaddr, netmask, gw;
+	ipaddr.addr	 = info.localIP;
+	netmask.addr = info.subnet;
+	gw.addr		 = info.gateway;
+	netif_set_addr(nif, &ipaddr, &netmask, &gw);
+	// netif_set_addr triggers the netif status callback again, but since DHCP
+	// is now stopped dhcp_supplied_address() returns false, so g_get_ip_cb is
+	// NOT re-entered — no infinite recursion.
+
+	// Restore configured DNS servers — DHCP may have overwritten them via option 6
+	// before we could stop it (reconnect/roam fallback path only).
+	ip4_addr_t d1, d2;
+	d1.addr = info.dns1;
+	d2.addr = info.dns2;
+	if (d1.addr)
+		dns_setserver(0, &d1);
+	if (d2.addr)
+		dns_setserver(1, &d2);
+
+	// Emit GOT_IP with the correct static address
+	wifiEventIpReceived(nif);
+}
+
+// ---------------------------------------------------------------------------
 
 void wifiEventSendArduino(EventId event) {
 	EventInfo eventInfo;
@@ -28,6 +79,28 @@ static void wifiEventStaConnected(void *arg) {
 	memcpy(eventInfo.wifi_sta_connected.bssid, pWiFi->BSSID(), 6);
 
 	pWiFi->postEvent(ARDUINO_EVENT_WIFI_STA_CONNECTED, eventInfo);
+
+	// If static IP is configured, apply it now and stop DHCP before the SDK
+	// starts it. wifi_sta_connect() always starts DHCP internally; we have no
+	// way to pass dhcp_mode to it (unlike BK72XX's bk_wlan_start_sta_adv_fix).
+	//
+	// IMPORTANT: stop DHCP *before* calling netif_set_addr. If DHCP is already
+	// BOUND when this event fires, netif_set_addr would trigger the netif status
+	// callback with dhcp_supplied_address==true, which would schedule an
+	// unnecessary wifiApplyStaticIpCallback. Stopping DHCP first ensures the
+	// status callback sees dhcp_supplied_address==false and stays silent.
+	WiFiNetworkInfo &info = pDATA->sta;
+	if (info.localIP) {
+		struct netif *ifs = netdev_get_netif(NETIF_IDX_STA);
+		ip4_addr_t ipaddr, netmask, gw;
+		ipaddr.addr	 = info.localIP;
+		netmask.addr = info.subnet;
+		gw.addr		 = info.gateway;
+		netifapi_dhcp_release_and_stop(ifs); // Stop first — safe (wifi_manager task)
+		netif_set_addr(ifs, &ipaddr, &netmask, &gw);
+		// Emit GOT_IP manually — DHCP is stopped so the netdev callback won't fire
+		wifiEventIpReceived(ifs);
+	}
 }
 
 static void wifiEventStaDisconnected(void *arg) {
@@ -99,6 +172,33 @@ static void wifiEventIpReceived(struct netif *nif) {
 	memset(&eventInfo, 0, sizeof(EventInfo));
 	if (!pWiFi || !nif)
 		return; // failsafe
+
+	// Fallback: DHCP completed and assigned an address despite our attempt to
+	// stop it in wifiEventStaConnected(). This can happen when:
+	//   (a) WIFI_MGR_EVENT_STA_CONNECTED fires before the SDK starts DHCP, so
+	//       netifapi_dhcp_release_and_stop() was a NOP and DHCP ran afterward; or
+	//   (b) a reconnect/roam caused the SDK to restart DHCP without triggering
+	//       WIFI_MGR_EVENT_STA_CONNECTED again (e.g. SDK-internal auto-reconnect).
+	//
+	// In this case we are being called from sta_netif_status_changed_cb(), which
+	// is the LwIP netif status callback invoked from within dhcp_recv() in the
+	// tcpip_thread.  Two important constraints apply:
+	//   - Cannot call dhcp_release_and_stop() directly: dhcp_recv() hasn't
+	//     returned yet, freeing the dhcp struct now would be a use-after-free.
+	//   - Cannot call netifapi_dhcp_release_and_stop(): it posts a message to
+	//     the tcpip_thread mailbox and waits for a reply — deadlock because we
+	//     ARE the tcpip_thread.
+	//
+	// Solution: schedule wifiApplyStaticIpCallback via tcpip_callback(). It will
+	// run in the tcpip_thread after the current message (dhcp_recv) has returned,
+	// so neither constraint applies there.
+	WiFiNetworkInfo &info = pDATA->sta;
+	if (info.localIP && dhcp_supplied_address(nif)) {
+		tcpip_callback(wifiApplyStaticIpCallback, nif);
+		// Do not emit GOT_IP here with the wrong DHCP address.
+		// wifiApplyStaticIpCallback will emit it with the static address.
+		return;
+	}
 
 	eventInfo.got_ip.if_index			  = 0;
 	eventInfo.got_ip.ip_changed			  = true;

--- a/cores/lightning-ln882h/arduino/libraries/WiFi/WiFiEvents.cpp
+++ b/cores/lightning-ln882h/arduino/libraries/WiFi/WiFiEvents.cpp
@@ -1,57 +1,8 @@
 /* Copyright (c) Etienne Le Cousin 2024-03-10. */
 
 #include "WiFiPrivate.h"
-#include <lwip/dhcp.h>	// dhcp_supplied_address, dhcp_release_and_stop
-#include <lwip/tcpip.h> // tcpip_callback
 
 static void wifiEventIpReceived(struct netif *nif);
-
-// ---------------------------------------------------------------------------
-// Async callback: scheduled via tcpip_callback() from within wifiEventIpReceived
-// when DHCP completes despite our best-effort stop in wifiEventStaConnected().
-//
-// Runs in the LwIP tcpip_thread AFTER dhcp_recv() has fully returned, so it
-// is safe to call dhcp_release_and_stop() directly here (no use-after-free).
-// We must NOT use netifapi_dhcp_release_and_stop() here — that function posts
-// a message to the tcpip_thread mailbox and waits for completion, which would
-// deadlock since we ARE the tcpip_thread.
-// ---------------------------------------------------------------------------
-static void wifiApplyStaticIpCallback(void *arg) {
-	struct netif *nif = (struct netif *)arg;
-	if (!pWiFi || !nif)
-		return;
-	WiFiNetworkInfo &info = pDATA->sta;
-	if (!info.localIP)
-		return;
-
-	// Stop DHCP — safe here, we're outside dhcp_recv()
-	dhcp_release_and_stop(nif);
-
-	// Apply the configured static address
-	ip4_addr_t ipaddr, netmask, gw;
-	ipaddr.addr	 = info.localIP;
-	netmask.addr = info.subnet;
-	gw.addr		 = info.gateway;
-	netif_set_addr(nif, &ipaddr, &netmask, &gw);
-	// netif_set_addr triggers the netif status callback again, but since DHCP
-	// is now stopped dhcp_supplied_address() returns false, so g_get_ip_cb is
-	// NOT re-entered — no infinite recursion.
-
-	// Restore configured DNS servers — DHCP may have overwritten them via option 6
-	// before we could stop it (reconnect/roam fallback path only).
-	ip4_addr_t d1, d2;
-	d1.addr = info.dns1;
-	d2.addr = info.dns2;
-	if (d1.addr)
-		dns_setserver(0, &d1);
-	if (d2.addr)
-		dns_setserver(1, &d2);
-
-	// Emit GOT_IP with the correct static address
-	wifiEventIpReceived(nif);
-}
-
-// ---------------------------------------------------------------------------
 
 void wifiEventSendArduino(EventId event) {
 	EventInfo eventInfo;
@@ -78,17 +29,6 @@ static void wifiEventStaConnected(void *arg) {
 	memcpy(eventInfo.wifi_sta_connected.ssid, ssid.c_str(), eventInfo.wifi_sta_connected.ssid_len + 1);
 	memcpy(eventInfo.wifi_sta_connected.bssid, pWiFi->BSSID(), 6);
 
-	pWiFi->postEvent(ARDUINO_EVENT_WIFI_STA_CONNECTED, eventInfo);
-
-	// If static IP is configured, apply it now and stop DHCP before the SDK
-	// starts it. wifi_sta_connect() always starts DHCP internally; we have no
-	// way to pass dhcp_mode to it (unlike BK72XX's bk_wlan_start_sta_adv_fix).
-	//
-	// IMPORTANT: stop DHCP *before* calling netif_set_addr. If DHCP is already
-	// BOUND when this event fires, netif_set_addr would trigger the netif status
-	// callback with dhcp_supplied_address==true, which would schedule an
-	// unnecessary wifiApplyStaticIpCallback. Stopping DHCP first ensures the
-	// status callback sees dhcp_supplied_address==false and stays silent.
 	WiFiNetworkInfo &info = pDATA->sta;
 	if (info.localIP) {
 		struct netif *ifs = netdev_get_netif(NETIF_IDX_STA);
@@ -96,11 +36,13 @@ static void wifiEventStaConnected(void *arg) {
 		ipaddr.addr	 = info.localIP;
 		netmask.addr = info.subnet;
 		gw.addr		 = info.gateway;
-		netifapi_dhcp_release_and_stop(ifs); // Stop first — safe (wifi_manager task)
+		netifapi_dhcp_release_and_stop(ifs);
 		netif_set_addr(ifs, &ipaddr, &netmask, &gw);
-		// Emit GOT_IP manually — DHCP is stopped so the netdev callback won't fire
+		// Emit GOT_IP manually - DHCP is stopped so the netdev callback won't fire
 		wifiEventIpReceived(ifs);
 	}
+
+	pWiFi->postEvent(ARDUINO_EVENT_WIFI_STA_CONNECTED, eventInfo);
 }
 
 static void wifiEventStaDisconnected(void *arg) {
@@ -172,33 +114,6 @@ static void wifiEventIpReceived(struct netif *nif) {
 	memset(&eventInfo, 0, sizeof(EventInfo));
 	if (!pWiFi || !nif)
 		return; // failsafe
-
-	// Fallback: DHCP completed and assigned an address despite our attempt to
-	// stop it in wifiEventStaConnected(). This can happen when:
-	//   (a) WIFI_MGR_EVENT_STA_CONNECTED fires before the SDK starts DHCP, so
-	//       netifapi_dhcp_release_and_stop() was a NOP and DHCP ran afterward; or
-	//   (b) a reconnect/roam caused the SDK to restart DHCP without triggering
-	//       WIFI_MGR_EVENT_STA_CONNECTED again (e.g. SDK-internal auto-reconnect).
-	//
-	// In this case we are being called from sta_netif_status_changed_cb(), which
-	// is the LwIP netif status callback invoked from within dhcp_recv() in the
-	// tcpip_thread.  Two important constraints apply:
-	//   - Cannot call dhcp_release_and_stop() directly: dhcp_recv() hasn't
-	//     returned yet, freeing the dhcp struct now would be a use-after-free.
-	//   - Cannot call netifapi_dhcp_release_and_stop(): it posts a message to
-	//     the tcpip_thread mailbox and waits for a reply — deadlock because we
-	//     ARE the tcpip_thread.
-	//
-	// Solution: schedule wifiApplyStaticIpCallback via tcpip_callback(). It will
-	// run in the tcpip_thread after the current message (dhcp_recv) has returned,
-	// so neither constraint applies there.
-	WiFiNetworkInfo &info = pDATA->sta;
-	if (info.localIP && dhcp_supplied_address(nif)) {
-		tcpip_callback(wifiApplyStaticIpCallback, nif);
-		// Do not emit GOT_IP here with the wrong DHCP address.
-		// wifiApplyStaticIpCallback will emit it with the static address.
-		return;
-	}
 
 	eventInfo.got_ip.if_index			  = 0;
 	eventInfo.got_ip.ip_changed			  = true;


### PR DESCRIPTION
Adds static IP support for LN882H. The LN882H SDK always starts DHCP internally in \wifi_sta_connect()\ with no option to disable it, so static IP is not supported at the SDK level. This PR implements static IP by stopping DHCP and applying the configured address after each connect, reconnect and roam event.

### Changes

1. **Apply static IP after connect** — stop DHCP and apply static IP in \wifiEventStaConnected()\ before the SDK hands over to the application. \wifi_sta_connect()\ always starts DHCP internally with no way to disable it.

2. **Fix forward declaration of \wifiEventIpReceived\** — required for the above.

3. **Ensure static IP survives reconnect and roam** — two additional cases:
   - Wrong order: \
etif_set_addr()\ was called before \
etifapi_dhcp_release_and_stop()\. When DHCP is already BOUND, this triggers the netif status callback with \dhcp_supplied_address==true\ before DHCP is stopped. Fixed: stop DHCP first.
   - Missing fallback: \wifiEventIpReceived()\ is called from inside \dhcp_recv()\ in the LwIP tcpip_thread. If DHCP completes despite the early stop (roaming, SDK-internal reconnect), the lease stays active. Cannot call \
etifapi_dhcp_release_and_stop()\ (deadlock) or \dhcp_release_and_stop()\ directly (use-after-free). Fixed: schedule \wifiApplyStaticIpCallback\ via \	cpip_callback()\ to run after \dhcp_recv()\ returns.

### Tested on
LN882H-based 2-gang light switch (DS-101JL) running ESPHome — static IP stable across power cycles, reconnects and roaming for several months.