### PR TITLE
[lightning-ln882h] Fix -Wregister warnings from CmBacktrace cmb_def.h

### DIFF
--- a/builder/family/lightning-ln882h.py
+++ b/builder/family/lightning-ln882h.py
@@ -32,7 +32,9 @@ queue.AppendPublic(
         "-Wno-write-strings",
         "-Wno-maybe-uninitialized",
     ],
-    CXXFLAGS=[],
+    CXXFLAGS=[
+        "-Wno-register",  # cmb_def.h uses 'register' keyword (removed in C++17)
+    ],
     CPPDEFINES=[
         # other options
         "ARM_MATH_CM4",


### PR DESCRIPTION
The LN882H SDK CmBacktrace library (`cmb_def.h`) uses the `register` storage class specifier in three inline assembly helpers: `cmb_get_msp()`, `cmb_get_psp()`, and `cmb_get_sp()`.

This keyword was removed in C++17 (P0001R1), producing spurious `-Wregister` warnings during every build when compiled with `-std=c++17` (as ESPHome does):

```
cmb_def.h:408:27: warning: ISO C++17 does not allow register storage class specifier [-Wregister]
  408 |         register uint32_t result;
```

The warning appears 9 times per build (3 inline functions x 3 translation units that include the header).

**Fix:** Add `-Wno-register` to `CXXFLAGS` in `builder/family/lightning-ln882h.py`. This is a no-op for plain LibreTiny builds (which do not use C++17) and only suppresses the warning for C++ consumers such as ESPHome.

No SDK sources are modified.