### PR TITLE
[lightning-ln882h] Fix duplicate MAC addresses on LN882H (fixes #338)

### DIFF
--- a/boards/_base/lightning-ln882hki-tuya.json
+++ b/boards/_base/lightning-ln882hki-tuya.json
@@ -1,0 +1,10 @@
+{
+	"flash": {
+		"tuya_kv": "0x1C5000+0x4000"
+	},
+	"doc": {
+		"params": {
+			"layout": "TuyaOpen LN882H default: KV partition starts at 0x001C5000 and size is 16 KB / 0x4000"
+		}
+	}
+}

--- a/boards/generic-ln882hki-tuya.json
+++ b/boards/generic-ln882hki-tuya.json
@@ -1,0 +1,16 @@
+{
+	"_base": [
+		"generic",
+		"lightning-ln882x",
+		"lightning-ln882hki",
+		"lightning-ln882hki-tuya",
+		"ic/ln882hk"
+	],
+	"build": {
+		"mcu": "ln882hk",
+		"variant": "generic-ln882hki-tuya"
+	},
+	"name": "Generic - LN882HKI (Tuya)",
+	"symbol": "LN882HKI_TUYA",
+	"vendor": "Tuya"
+}

--- a/boards/ln-cb3s-v1.0.json
+++ b/boards/ln-cb3s-v1.0.json
@@ -2,6 +2,7 @@
 	"_base": [
 		"lightning-ln882x",
 		"lightning-ln882hki",
+		"lightning-ln882hki-tuya",
 		"ic/ln882hk",
 		"pcb/ln-cb3s-v1.0"
 	],

--- a/cores/lightning-ln882h/base/api/lt_init.c
+++ b/cores/lightning-ln882h/base/api/lt_init.c
@@ -3,6 +3,19 @@
 #include <libretiny.h>
 #include <sdk_private.h>
 
+// Declared in components/utils/ln_misc.h; compiled in ln882h_net.
+// Not thread-safe - safe here since lt_init_family() runs before the RTOS scheduler.
+extern int ln_generate_random_mac(uint8_t *addr);
+
+// hal_flash_read: only needed on Tuya board variants (FLASH_TUYA_KV_OFFSET defined).
+// Forward-declared to avoid the hexdump macro conflict in hal_flash.h.
+#ifdef FLASH_TUYA_KV_OFFSET
+extern uint8_t hal_flash_read(uint32_t offset, uint32_t length, uint8_t *buffer);
+#endif
+
+// Factory-default STA MAC on every LN882H - sentinel for "not yet unique".
+static const uint8_t WIFI_MAC_FACTORY_DEFAULT[6] = {0x00, 0x50, 0xC2, 0x5E, 0x10, 0x88};
+
 extern uint8_t uart_print_port;
 extern Serial_t m_LogSerial;
 
@@ -11,6 +24,79 @@ static void lt_init_log(void) {
 	uart_print_port = LT_UART_DEFAULT_LOGGER;
 	// default SDK print port
 	serial_init(&m_LogSerial, LT_UART_DEFAULT_PORT, CFG_UART_BAUDRATE_LOG, NULL);
+}
+
+#ifdef FLASH_TUYA_KV_OFFSET
+static bool lt_tuya_kv_read_sta_mac(uint8_t *mac_out) {
+	static const uint8_t IT_MAGIC[8]	= "it_magic";
+	static const uint8_t STA_MAC_KEY[9] = "6_sta_mac";
+
+	const uint32_t kv_base = FLASH_TUYA_KV_OFFSET;
+	const uint32_t kv_size = FLASH_TUYA_KV_LENGTH;
+	uint8_t entry[31];
+	bool found = false;
+	uint32_t off;
+
+	for (off = 0; off + sizeof(entry) <= kv_size; off++) {
+		hal_flash_read(kv_base + off, 8, entry);
+		if (memcmp(entry, IT_MAGIC, 8) != 0)
+			continue;
+		hal_flash_read(kv_base + off + 8, 23, entry + 8);
+		uint16_t val_size = entry[10] | ((uint16_t)entry[11] << 8);
+		if (val_size != 6)
+			goto next;
+		if (memcmp(entry + 16, STA_MAC_KEY, 9) != 0)
+			goto next;
+		if (memcmp(entry + 25, WIFI_MAC_FACTORY_DEFAULT, 6) == 0)
+			goto next;
+		{
+			bool all_ff = true;
+			for (int i = 0; i < 6; i++)
+				if (entry[25 + i] != 0xFF) {
+					all_ff = false;
+					break;
+				}
+			if (all_ff)
+				goto next;
+		}
+		memcpy(mac_out, entry + 25, 6);
+		found = true; // keep scanning -- last entry wins in BLK_V1.0 log
+	next:
+		off += 7; // outer off++ gives total advance of 8
+	}
+	return found;
+}
+#endif // FLASH_TUYA_KV_OFFSET
+
+static void lt_init_unique_mac(void) {
+	uint8_t mac[6];
+	if (SYSPARAM_ERR_NONE != sysparam_sta_mac_get(mac))
+		return;
+	if (memcmp(mac, WIFI_MAC_FACTORY_DEFAULT, 6) != 0)
+		return; // step 1: already unique
+#ifdef FLASH_TUYA_KV_OFFSET
+	if (lt_tuya_kv_read_sta_mac(mac)) {
+		LT_I(
+			"Restored Tuya factory MAC: %02X:%02X:%02X:%02X:%02X:%02X",
+			mac[0],
+			mac[1],
+			mac[2],
+			mac[3],
+			mac[4],
+			mac[5]
+		);
+		sysparam_sta_mac_update(mac);
+		mac[0] |= 0x02; // locally-administered bit
+		sysparam_softap_mac_update(mac);
+		return;
+	}
+#endif // FLASH_TUYA_KV_OFFSET
+	if (ln_generate_random_mac(mac) != 0)
+		return;
+	LT_I("Generated random unique MAC: %02X:%02X:%02X:%02X:%02X:%02X", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+	sysparam_sta_mac_update(mac);
+	mac[0] |= 0x02;
+	sysparam_softap_mac_update(mac);
 }
 
 void lt_init_family() {
@@ -41,6 +127,8 @@ void lt_init_family() {
 
 	// init system parameter
 	sysparam_integrity_check_all();
+	// randomize MAC if still at factory default (first boot after flash)
+	lt_init_unique_mac();
 
 	ln_pm_sleep_mode_set(ACTIVE);
 	// ln_pm_always_clk_disable_select(CLK_G_I2S | CLK_G_WS2811 | CLK_G_SDIO);


### PR DESCRIPTION
Fixes #338

## Problem

Every LN882H device ships with the same factory-default MAC address (`00:50:C2:5E:10:88`) stored in KV flash. `sysparam_integrity_check_all()` (called during `lt_init_family()`) writes this placeholder on first boot and never replaces it. Every device on the same network therefore shares one MAC, causing ARP conflicts and connection failures.

## Fix

Add `lt_init_unique_mac()` called immediately after `sysparam_integrity_check_all()` in `lt_init.c`. It resolves the MAC address in priority order — once, on first boot after flash. Every subsequent boot returns in step 1 immediately.

### Priority order

**Step 1 — sysparam KV already unique**
Read the stored STA MAC via `sysparam_sta_mac_get()`. If it differs from the factory sentinel, return immediately. This is the fast path on every boot after the first, and fully covers the LibreTiny→LibreTiny OTA case: the sysparam KV lives at `0x1E0000`, which is outside the OTA partition and is never erased by OTA.

**Step 2 — Restore Tuya factory MAC from BLK_V1.0 KV**
Tuya assigns every LN882H a unique MAC at the factory and writes it as a second `6_sta_mac` entry in a BLK_V1.0 append-log KV store at flash offset `0x1C5000`. Scan for the last valid non-sentinel entry and restore it to sysparam KV.

This region lies within the OTA partition (`0x133000`–`0x1DD000`), but **no partition layout changes are needed**: OTA writes are block-addressed and the current firmware (~530 KB) ends at ~`0x1B4700`, well short of `0x1C5000`. UART full-flash similarly only covers `0x000000`–`0x088000`. The Tuya KV is naturally preserved under both flash methods.

**Step 3 — TRNG fallback**
If the Tuya KV is absent or erased (e.g. UART flash with full-chip erase option), generate a unique address via `ln_generate_random_mac()` (hardware TRNG, already compiled in via `ln882h_net`). This mirrors the approach used in OpenBeken.

In all cases the SoftAP MAC is derived by setting the locally-administered bit (`mac[0] |= 0x02`) on the STA MAC.

## Analysis

This fix is based on binary examination of **5 unique Tuya LN882H flash dumps** (4× DS-101JL wall switch + 1× GU10 bulb from issue #338), including devices in three states: never provisioned, provisioned via Tuya app, and provisioned and in use for weeks.

Key findings:
- The unique MAC is **factory-assigned at manufacturing time**, not during Tuya app provisioning — even devices that were never connected to a Tuya account carry a unique `6_sta_mac` entry
- The BLK_V1.0 KV region (`0x1C5000`–`0x1C9000`, 4 blocks × 4 KB) has an identical layout across all examined devices: sentinel at `0x1C51EB`, unique MAC at `0x1C5423`
- BLK_V1.0 keys are **not** null-terminated; the format is `it_magic(8) + crc16(2) + val_size_u16_le(2) + prev_ptr_u32_le(4) + key_raw(N) + value_raw`
- LibreTiny's OTA writer (`uf2_write`) uses `offset = part->offset + block->addr` — it only erases sectors for UF2 blocks actually present in the image; no block targets `0x1C5000`

Detailed analysis is posted as a comment on this PR.

## Safety

- `lt_tuya_kv_read_sta_mac()` is read-only; it never writes to flash
- `ln_generate_random_mac()` is not thread-safe but is called before the RTOS scheduler starts
- The sentinel check (`memcmp` against `{0x00,0x50,0xC2,0x5E,0x10,0x88}`) ensures existing devices with a persisted unique MAC in sysparam KV are never affected
