### PR TITLE
[beken-72xx] Keep 802.11n enabled at weak RSSI

### DIFF
--- a/cores/beken-72xx/base/fixups/wlan_ui.c
+++ b/cores/beken-72xx/base/fixups/wlan_ui.c
@@ -147,3 +147,31 @@ OSStatus bk_wlan_start_sta_adv_fix(network_InitTypeDef_adv_st *inNetworkInitPara
 
     return 0;
 }
+
+/*
+ * Make the SDK's 802.11n weak-RSSI fallback threshold configurable.
+ *
+ * The rwnx MAC blob (scanu.o: scanu_change_ht_supported) compares the RSSI
+ * of the join-scan result against a threshold, and if the frame is weaker,
+ * clears the STA's HT capability (me_env.ht_supported) before associating.
+ * The device then associates as 802.11g-only. HT is only restored at the
+ * start of the next scan (scanu_recover_ht_supported), so whether a given
+ * association ends up 11n or 11g is effectively racy across reboots.
+ *
+ * The threshold defaults to -50 dBm unless the weak hook
+ * rwnx_get_noht_rssi_thresold() (declared in
+ * beken378/ip/lmac/src/rwnx/rwnx_config.h) is defined. Define it here so
+ * the threshold can be set at build time via -DLT_BK_NOHT_RSSI_THRESHOLD.
+ *
+ * The blob truncates the return value to signed 8-bit, so valid values are
+ * -128..-1. This lives in wlan_ui.c (not its own file) so that it is always
+ * extracted from the fixups archive: the blob's reference to the hook is
+ * weak and would not pull a standalone object out of the library.
+ */
+#ifndef LT_BK_NOHT_RSSI_THRESHOLD
+#define LT_BK_NOHT_RSSI_THRESHOLD -50
+#endif
+
+__attribute__((weak)) int rwnx_get_noht_rssi_thresold(void) {
+    return LT_BK_NOHT_RSSI_THRESHOLD;
+}

--- a/cores/beken-72xx/base/fixups/wlan_ui.c
+++ b/cores/beken-72xx/base/fixups/wlan_ui.c
@@ -164,12 +164,14 @@ OSStatus bk_wlan_start_sta_adv_fix(network_InitTypeDef_adv_st *inNetworkInitPara
  * the threshold can be set at build time via -DLT_BK_NOHT_RSSI_THRESHOLD.
  *
  * The blob truncates the return value to signed 8-bit, so valid values are
- * -128..-1. This lives in wlan_ui.c (not its own file) so that it is always
+ * -128..-1. The default of -100 keeps HT enabled at any usable signal
+ * level; override with -DLT_BK_NOHT_RSSI_THRESHOLD=-50 to restore the
+ * vendor behavior. This lives in wlan_ui.c (not its own file) so that it is always
  * extracted from the fixups archive: the blob's reference to the hook is
  * weak and would not pull a standalone object out of the library.
  */
 #ifndef LT_BK_NOHT_RSSI_THRESHOLD
-#define LT_BK_NOHT_RSSI_THRESHOLD -50
+#define LT_BK_NOHT_RSSI_THRESHOLD -100
 #endif
 
 __attribute__((weak)) int rwnx_get_noht_rssi_thresold(void) {


### PR DESCRIPTION
## Problem

BK72xx STAs frequently associate as 802.11g-only (no HT capability in the association request) even though the chip and AP both support 802.11n. Whether a given boot ends up on 11n or 11g appears random, and power-cycling does not reliably change it. The UART logs in #297 show the same signature (`no ht in scan` followed by a legacy association).

## Root cause

Disassembly of `scanu.o` in `librwnx_bk7231u.a` (the same code is present in the bk7231n and bk7251 libs) shows:

- `scanu_frame_handler` passes the RSSI of the join-scan result frame to `scanu_change_ht_supported()`.
- `scanu_change_ht_supported()` compares it against a threshold obtained from `rwnx_get_noht_rssi_thresold()` — a weak hook declared in `beken378/ip/lmac/src/rwnx/rwnx_config.h:522` and defined nowhere — falling back to a hardcoded **-50 dBm**. If the scan frame is weaker, it clears `me_env.ht_supported` (UART log: `dis ht_support`), so the subsequent association request omits the HT capability IE and the STA associates as 802.11g.
- HT is restored only at the start of the next scan (`scanu_recover_ht_supported`, called from `scanu_start`), and `sm_assoc_rsp_handler` separately latches an `is_n_only_mode` flag that suppresses the disable path — which is why the resulting mode is racy/intermittent rather than deterministic.

-50 dBm is a signal level most real-world devices don't reach, so in practice most BK72xx devices run 11g most of the time.

## Fix

Define the SDK's weak threshold hook with a -100 dBm default, overridable via `-DLT_BK_NOHT_RSSI_THRESHOLD` (e.g. `-50` to restore the vendor behavior). The blob truncates the return value to signed 8-bit, so valid values are -128..-1.

The definition lives in `fixups/wlan_ui.c` rather than its own file: the blob's reference to the hook is weak, and a weak reference does not extract a standalone member from the fixups archive (verified — in a separate file the object compiles but is not linked). It is itself marked `__attribute__((weak))` so user code can still provide its own definition.

## Verification

Tested on a BK7231T Tuya bulb (ESPHome 2026.5.3, LibreTiny 1.13.0) at -70 dBm against OpenWrt APs (MT7622, 2.4 GHz HT20):

- Before: associated `[WMM]` only (hostapd station flags) after most reboots, 11g rates.
- After: associates `[WMM][HT]` deterministically across reboots, MCS rates in use. DTIM WiFi power save unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)