### PR TITLE
[common] Remove __DATE__/__TIME__ from banner macro

### DIFF
--- a/cores/common/arduino/libraries/inline/ESP/ESP.h
+++ b/cores/common/arduino/libraries/inline/ESP/ESP.h
@@ -50,8 +50,10 @@ class EspClass {
 	/** @copydoc LT_VERSION_STR() */
 	inline String getCoreVersion() { return LT_VERSION_STR; }
 
-	/** @copydoc LT_BANNER_STR() */
-	inline String getFullVersion() { return LT_BANNER_STR; }
+	/** @brief Full version string; the compile timestamp is appended at
+	 * runtime so that __DATE__/__TIME__ stay out of this header, which
+	 * would otherwise defeat compiler caches (see libretiny.h). */
+	inline String getFullVersion() { return String(LT_BANNER_STR ", compiled at ") + lt_get_build_timestamp(); }
 
 	inline uint8_t getBootVersion() { return 0; }
 

--- a/cores/common/base/api/lt_device.c
+++ b/cores/common/base/api/lt_device.c
@@ -8,6 +8,10 @@ const char *lt_get_version() {
 	return LT_VERSION_STR;
 }
 
+// lt_get_build_timestamp() is intentionally defined in lt_main.c -
+// it must stay in the single TU that carries __DATE__/__TIME__,
+// otherwise this file would be rebuilt (and not cacheable) every build
+
 const char *lt_get_board_code() {
 	return LT_BOARD_STR;
 }

--- a/cores/common/base/api/lt_device.h
+++ b/cores/common/base/api/lt_device.h
@@ -53,6 +53,14 @@ typedef enum {
 const char *lt_get_version();
 
 /**
+ * @brief Get the compilation timestamp string ("MMM DD YYYY HH:MM:SS").
+ * Kept out of the version macros so that __DATE__/__TIME__ only appear
+ * in a single translation unit (see libretiny.h); can be overridden by
+ * defining LT_BUILD_TIMESTAMP, e.g. for reproducible builds.
+ */
+const char *lt_get_build_timestamp();
+
+/**
  * @brief Get board code.
  */
 const char *lt_get_board_code();

--- a/cores/common/base/libretiny.h
+++ b/cores/common/base/libretiny.h
@@ -27,8 +27,12 @@
 #define LT_BOARD_STR	   STRINGIFY_MACRO(LT_BOARD)
 #define GCC_VERSION_STR \
 	STRINGIFY_MACRO(__GNUC__) "." STRINGIFY_MACRO(__GNUC_MINOR__) "." STRINGIFY_MACRO(__GNUC_PATCHLEVEL__)
-#define LT_BANNER_STR                                                                                                \
-	"LibreTiny v" LT_VERSION_STR " on " LT_BOARD_STR ", compiled at " __DATE__ " " __TIME__ ", GCC " GCC_VERSION_STR \
+// Note: the banner deliberately avoids __DATE__/__TIME__. This header is
+// included by every source file, and the presence of those tokens anywhere
+// in a translation unit defeats compiler caches (ccache) and reproducible
+// builds. The compile timestamp is logged from lt_main.c instead.
+#define LT_BANNER_STR                                                         \
+	"LibreTiny v" LT_VERSION_STR " on " LT_BOARD_STR ", GCC " GCC_VERSION_STR \
 	" (-O" STRINGIFY_MACRO(__OPTIMIZE_LEVEL__) ")"
 
 // Functional macros

--- a/cores/common/base/lt_main.c
+++ b/cores/common/base/lt_main.c
@@ -6,6 +6,16 @@
 
 fal_partition_t fal_root_part = NULL;
 
+// the only place where __DATE__/__TIME__ may appear (see libretiny.h);
+// can be overridden for reproducible builds, e.g. from SOURCE_DATE_EPOCH
+#ifndef LT_BUILD_TIMESTAMP
+#define LT_BUILD_TIMESTAMP __DATE__ " " __TIME__
+#endif
+
+const char *lt_get_build_timestamp() {
+	return LT_BUILD_TIMESTAMP;
+}
+
 // Initialize C library
 void __libc_init_array(void);
 // Main app entrypoint
@@ -20,7 +30,7 @@ int lt_main(void) {
 	// log the compile timestamp; kept out of LT_BANNER_STR (see libretiny.h)
 	// so only this one file is rebuilt when the time changes; uses LT_LOG
 	// directly, like LT_BANNER(), so it prints regardless of LT_LOGLEVEL
-	LT_LOG(LT_LEVEL_INFO, __FUNCTION__, __LINE__, "Compiled at " __DATE__ " " __TIME__);
+	LT_LOG(LT_LEVEL_INFO, __FUNCTION__, __LINE__, "Compiled at " LT_BUILD_TIMESTAMP);
 	// initialize C library
 	__libc_init_array();
 	// inform about the reset reason

--- a/cores/common/base/lt_main.c
+++ b/cores/common/base/lt_main.c
@@ -17,6 +17,10 @@ int lt_main(void) {
 	lt_init_variant();
 	// print a startup banner
 	LT_BANNER();
+	// log the compile timestamp; kept out of LT_BANNER_STR (see libretiny.h)
+	// so only this one file is rebuilt when the time changes; uses LT_LOG
+	// directly, like LT_BANNER(), so it prints regardless of LT_LOGLEVEL
+	LT_LOG(LT_LEVEL_INFO, __FUNCTION__, __LINE__, "Compiled at " __DATE__ " " __TIME__);
 	// initialize C library
 	__libc_init_array();
 	// inform about the reset reason

--- a/docs/dev/config.md
+++ b/docs/dev/config.md
@@ -121,6 +121,7 @@ Options for controlling default UART log output.
 - `LT_USE_TIME` (0) - enables implementation of `gettimeofday()` and `settimeofday()`; checks for `millis()` overflows periodically
 - `LT_MICROS_HIGH_RES` (1) - count runtime microseconds using a high-resolution timer (if possible); disable if your application doesn't need `micros()`
 - `LT_AUTO_DOWNLOAD_REBOOT` (1) - automatically reboot into "download mode" after detecting a flashing protocol command; [read more](../flashing/tools/adr.md)
+- `LT_BUILD_TIMESTAMP` (`__DATE__ " " __TIME__`) - overrides the compile timestamp logged at boot and returned by `lt_get_build_timestamp()`; lets reproducible builds set a deterministic value, e.g. derived from `SOURCE_DATE_EPOCH`. This is a string, so it needs quoting: `-D LT_BUILD_TIMESTAMP='"Jan  1 2024 00:00:00"'`
 
 ### Family configuration
 


### PR DESCRIPTION
Follow up to esphome/esphome#17726, which enabled ccache for ESPHome's LibreTiny builds; the hit rate there is capped by this banner macro, so the remaining fix belongs here.

libretiny.h is included by every source file, and having __DATE__ __TIME__ in LT_BANNER_STR defeats compiler caches (ccache direct mode) and reproducible builds for the whole tree. This moves the compile timestamp out of the banner; lt_main.c logs it right after LT_BANNER(), using LT_LOG directly like the banner does so it prints regardless of LT_LOGLEVEL, and only that one file rebuilds when the time changes.

The intended visible change is that the startup banner no longer contains the compile timestamp; it is printed on its own log line right after the banner. The timestamp stays reachable through a new lt_get_build_timestamp() accessor, which ESP.getFullVersion() appends at runtime, so its result keeps the timestamp without pulling __DATE__ into every TU. The value can be overridden by defining LT_BUILD_TIMESTAMP, letting reproducible builds wire in SOURCE_DATE_EPOCH.

Verified with ESPHome pointing the framework source at this branch, on bk72xx (cb3s) and rtl87xx (bw15); the firmwares contain the new banner and the separate timestamp line, a lambda calling ESP.getFullVersion() compiles and links against the new accessor, and a full rebuild after esphome clean goes from roughly 80 percent ccache hits to 421 of 422, finishing in 18 seconds instead of 72.

The vendor SDKs were also checked; framework-beken-bdk and framework-realtek-amb1 are clean, framework-realtek-ambz2 has three .c files using the macros with single file impact each, and framework-lightning-ln882h defines LN882H_SDK_BUILD_DATE_TIME in mcu/ln882h/ln882h.h, which poisons every LN882x file the same way and needs a one line fix in that repo.