### PR TITLE
[core] Write custom option headers to an env independent include dir

### DIFF
--- a/builder/utils/env.py
+++ b/builder/utils/env.py
@@ -2,6 +2,7 @@
 
 import json
 import sys
+from hashlib import sha1
 from os import makedirs
 from os.path import isdir, join
 from subprocess import PIPE, Popen
@@ -165,9 +166,11 @@ def env_apply_custom_options(env: Environment, platform: PlatformBase):
     # Note: deliberately not ${BUILD_DIR}, which embeds the env name; keeping
     # the -I path identical across envs lets compiler caches (ccache with
     # base_dir) share results between projects that differ only by env name.
-    # The headers are rewritten at the start of every build, so sequential
-    # multi-env builds each get their own options applied.
-    header_dir = join("${PROJECT_BUILD_DIR}", "include")
+    # The directory is keyed on the option content instead, so envs with
+    # different options can never pick up each other's generated headers,
+    # while envs with identical options share one path.
+    opts_key = sha1(json.dumps(opts, sort_keys=True).encode()).hexdigest()[:12]
+    header_dir = join("${PROJECT_BUILD_DIR}", "include", opts_key)
     real_dir = env.subst(header_dir)
     makedirs(real_dir, exist_ok=True)
 
@@ -176,18 +179,17 @@ def env_apply_custom_options(env: Environment, platform: PlatformBase):
         options: Dict[str, str]
         # open the header file for writing
         header = header.replace("#", ".")
-        f = open(join(real_dir, header), "w")
-        f.write(f'#include_next "{header}"\n' "\n" "#pragma once\n" "\n")
-        # write all #defines
-        for k, v in options.items():
-            f.write(
-                f"// {k} = {v}\n"
-                f"#ifdef {k}\n"
-                f"#undef {k}\n"
-                f"#endif\n"
-                f"#define {k} {v}\n"
-            )
-        f.close()
+        with open(join(real_dir, header), "w") as f:
+            f.write(f'#include_next "{header}"\n' "\n" "#pragma once\n" "\n")
+            # write all #defines
+            for k, v in options.items():
+                f.write(
+                    f"// {k} = {v}\n"
+                    f"#ifdef {k}\n"
+                    f"#undef {k}\n"
+                    f"#endif\n"
+                    f"#define {k} {v}\n"
+                )
     # prepend newly created headers before any other
     env.Prepend(CPPPATH=[header_dir])
 

--- a/builder/utils/env.py
+++ b/builder/utils/env.py
@@ -162,7 +162,12 @@ def env_apply_custom_options(env: Environment, platform: PlatformBase):
     opts = platform.custom_opts.get("options", None)
     if not opts:
         return
-    header_dir = join("${BUILD_DIR}", "include")
+    # Note: deliberately not ${BUILD_DIR}, which embeds the env name; keeping
+    # the -I path identical across envs lets compiler caches (ccache with
+    # base_dir) share results between projects that differ only by env name.
+    # The headers are rewritten at the start of every build, so sequential
+    # multi-env builds each get their own options applied.
+    header_dir = join("${PROJECT_BUILD_DIR}", "include")
     real_dir = env.subst(header_dir)
     makedirs(real_dir, exist_ok=True)
 

--- a/builder/utils/env.py
+++ b/builder/utils/env.py
@@ -3,8 +3,8 @@
 import json
 import sys
 from hashlib import sha1
-from os import makedirs
-from os.path import isdir, join
+from os import getpid, makedirs, replace
+from os.path import isdir, isfile, join
 from subprocess import PIPE, Popen
 from typing import Dict
 
@@ -168,7 +168,10 @@ def env_apply_custom_options(env: Environment, platform: PlatformBase):
     # base_dir) share results between projects that differ only by env name.
     # The directory is keyed on the option content instead, so envs with
     # different options can never pick up each other's generated headers,
-    # while envs with identical options share one path.
+    # while envs with identical options share one path. Directories of
+    # no-longer-used option sets are left behind on purpose; they are
+    # inert (never on CPPPATH) and pruning them here would race against
+    # a concurrent build of another env.
     opts_key = sha1(json.dumps(opts, sort_keys=True).encode()).hexdigest()[:12]
     header_dir = join("${PROJECT_BUILD_DIR}", "include", opts_key)
     real_dir = env.subst(header_dir)
@@ -177,19 +180,31 @@ def env_apply_custom_options(env: Environment, platform: PlatformBase):
     for header, options in opts.items():
         header: str
         options: Dict[str, str]
-        # open the header file for writing
+        # build the header content in memory
         header = header.replace("#", ".")
-        with open(join(real_dir, header), "w") as f:
-            f.write(f'#include_next "{header}"\n' "\n" "#pragma once\n" "\n")
-            # write all #defines
-            for k, v in options.items():
-                f.write(
-                    f"// {k} = {v}\n"
-                    f"#ifdef {k}\n"
-                    f"#undef {k}\n"
-                    f"#endif\n"
-                    f"#define {k} {v}\n"
-                )
+        text = f'#include_next "{header}"\n' "\n" "#pragma once\n" "\n"
+        # write all #defines
+        for k, v in options.items():
+            text += (
+                f"// {k} = {v}\n"
+                f"#ifdef {k}\n"
+                f"#undef {k}\n"
+                f"#endif\n"
+                f"#define {k} {v}\n"
+            )
+        # the content is fully determined by the directory key, so an
+        # existing file never needs rewriting; writing through a temp file
+        # keeps the swap atomic, so a concurrent build of another env with
+        # identical options can never see a partially written header
+        path = join(real_dir, header)
+        if isfile(path):
+            with open(path, "r") as f:
+                if f.read() == text:
+                    continue
+        tmp = f"{path}.{getpid()}.tmp"
+        with open(tmp, "w") as f:
+            f.write(text)
+        replace(tmp, path)
     # prepend newly created headers before any other
     env.Prepend(CPPPATH=[header_dir])
 


### PR DESCRIPTION
Follow up to esphome/esphome#17726, which enabled ccache for ESPHome's LibreTiny builds; sharing the cache between devices is blocked by this generated header path, so the remaining fix belongs here.

The generated custom option headers (lwipopts.h, sys_config.h and friends) are currently written to ${BUILD_DIR}/include, a path that embeds the PlatformIO env name. That -I flag makes every compile command unique per env, so compiler caches like ccache can never share results between projects that differ only by env name; ESPHome creates one env per device, so nothing is shared between devices.

This writes them to ${PROJECT_BUILD_DIR}/include/<hash> instead, where the hash is derived from the option content. The path no longer contains the env name, so with ccache base_dir the compile commands hash identically across devices with the same options; envs with different options get different directories, so they can never pick up each other's generated headers, and concurrent builds of envs with identical options write identical bytes. The header writes also moved to a with block so a failed build cannot leave a truncated header behind.

Verified with ESPHome pointing the framework source at this branch; a clean bk72xx build succeeds, the headers land in the content keyed directory, 292 dependency files reference them at the new path with none referencing the old one, and a second compile reproduces the same hash with nothing rebuilt.