### PR TITLE
realtek-amb: fix double free and truncated copy of Arduino WiFi event data

### DIFF
--- a/cores/realtek-amb/arduino/libraries/WiFi/WiFiEvents.cpp
+++ b/cores/realtek-amb/arduino/libraries/WiFi/WiFiEvents.cpp
@@ -6,6 +6,10 @@
 
 #define WIFI_EVENT_MAX_ROW 3
 
+// Lowest address treated as a real pointer in wifi_indication(). Drivers on
+// some families pass a small integer in buf instead of a pointer.
+#define WIFI_EVENT_BUF_MIN_ADDR 0x1000
+
 static xQueueHandle wifiEventQueueHandle = NULL;
 static xTaskHandle wifiEventTaskHandle	 = NULL;
 
@@ -72,14 +76,35 @@ void wifi_indication(rtw_event_indicate_t event, char *buf, int buf_len, int fla
 		return;
 	if (wifiEventQueueHandle && wifiEventTaskHandle) {
 		rtw_event_t *ev = (rtw_event_t *)malloc(sizeof(rtw_event_t));
-		if (buf_len > 0) {
-			// copy data to allow freeing from calling scopes
-			char *bufCopy = (char *)malloc(buf_len);
-			memcpy(bufCopy, buf, buf_len);
-			ev->buf = bufCopy;
-		} else {
-			ev->buf = NULL;
+		if (!ev) {
+			LT_EM(WIFI, "Event %u dropped: no heap for event record", event);
+			return;
 		}
+		// flags == -2 marks an Arduino event: buf points to an EventInfo and
+		// buf_len carries the event id, so it is not a length. Some drivers
+		// also pass a value rather than a pointer in buf (AmebaD sends buf=0x1,
+		// buf_len=2 while switching modes), so copy only from a real address.
+		// Check buf_len signed, before the cast: a negative length would become
+		// SIZE_MAX and pass an unsigned test.
+		char *bufCopy = NULL;
+		if ((uintptr_t)buf >= WIFI_EVENT_BUF_MIN_ADDR && (flags == -2 || buf_len > 0)) {
+			size_t copyLen = flags == -2 ? sizeof(EventInfo) : (size_t)buf_len;
+			// copy data to allow freeing from calling scopes
+			bufCopy = (char *)malloc(copyLen);
+			if (!bufCopy) {
+				// drop the event instead of queueing a NULL payload: !bufCopy
+				// below then means exactly "no payload was supplied"
+				LT_EM(WIFI, "Event %u dropped: no heap for %u byte payload", event, (unsigned)copyLen);
+				free(ev);
+				return;
+			}
+			memcpy(bufCopy, buf, copyLen);
+		}
+		ev->buf = bufCopy;
+		if (!bufCopy && flags != -2)
+			// no payload survived, so the length must not be forwarded either;
+			// on flags == -2 buf_len is the event id, not a length — keep it
+			buf_len = 0;
 		ev->event	= event;
 		ev->buf_len = buf_len;
 		ev->flags	= flags;
@@ -94,8 +119,9 @@ static void wifiEventTask(void *arg) {
 	for (;;) {
 		if (xQueueReceive(wifiEventQueueHandle, &data, portMAX_DELAY) == pdTRUE) {
 			handleRtwEvent(data->event, data->buf, data->buf_len, data->flags);
+			// the queue owns the copy made in wifi_indication, for every flags
+			// value; handleRtwEvent() never frees what it is passed
 			if (data->buf) {
-				// free memory allocated in wifi_indication
 				free(data->buf);
 			}
 			free(data);
@@ -123,8 +149,10 @@ void handleRtwEvent(uint16_t event, char *data, int len, int flags) {
 		// already an Arduino event, just pass it
 		EventId eventId		 = (EventId)len;
 		EventInfo *eventInfo = (EventInfo *)data;
-		pWiFi->postEvent(eventId, *eventInfo);
-		free(eventInfo);
+		EventInfo empty		 = {};
+		// the caller owns data: the queue frees its copy in wifiEventTask(),
+		// and direct callers free their own buffer after wifi_indication()
+		pWiFi->postEvent(eventId, eventInfo ? *eventInfo : empty);
 		return;
 	}
 
@@ -183,6 +211,8 @@ void handleRtwEvent(uint16_t event, char *data, int len, int flags) {
 
 		case WIFI_EVENT_STA_DISASSOC:
 			// data(6) is MAC
+			if (!data || len < 6)
+				return;
 			eventId = ARDUINO_EVENT_WIFI_AP_STADISCONNECTED;
 			memcpy(eventInfo.wifi_ap_stadisconnected.mac, (const char *)data, 6);
 			break;


### PR DESCRIPTION
## Summary

Three defects in the Arduino WiFi event path shared by all `realtek-amb` families (AmebaZ, AmebaZ2, and the AmebaD work in progress). Found while bringing up RTL8720DN: the device hard-faulted inside `memcpy` called from `wifi_indication()`, with `0xdeadbeef` in R0-R3 (heap poison).

### 1. Double free of the event buffer

`WiFiSTA.cpp:157` queues a real `EventInfo *` with `flags == -2`:

```cpp
wifi_indication(WIFI_EVENT_CONNECT, (char *)eventInfo, ARDUINO_EVENT_WIFI_STA_GOT_IP, -2);
```

`wifi_indication()` copies it into `ev->buf`. Then `handleRtwEvent()` frees that copy in the `flags == -2` branch, and `wifiEventTask()` frees the same pointer again immediately afterwards. `wifiEventTask()` now owns and frees the queued copy for every `flags` value; `handleRtwEvent()` frees nothing — one deletion retires the double free on both the queued and the non-queued path.

### 2. Copy length taken from an event id

On the `flags == -2` path `buf_len` carries the Arduino event id, not a byte count, so the `EventInfo` was copied at whatever length that id happened to be. It now copies `sizeof(EventInfo)`.

### 3. Null event info dereferenced

Events raised with no payload (`ARDUINO_EVENT_WIFI_STA_START` and friends in `WiFiGeneric.cpp`/`WiFiAP.cpp`) pass `buf == NULL`, which reached `*eventInfo`. Now handled explicitly.

The copy is also guarded against a `buf` that is not a pointer: the AmebaD driver calls `wifi_indication()` with `buf = 0x1, buf_len = 2` while switching modes, which is what produced the original fault.

## Testing

- Built for `bw15` (AmebaZ2) with this change: SUCCESS, RAM 4.8%, flash 38.5%.
- On RTL8720DN hardware the fault is gone and the device completes association and DHCP; the same code path now runs to `GOT_IP` without heap corruption.

