### PR TITLE
[realtek-amb] pinRemoveMode(): null the driver pointers after free

### DIFF
--- a/cores/realtek-amb/arduino/src/wiring.c
+++ b/cores/realtek-amb/arduino/src/wiring.c
@@ -56,17 +56,23 @@ void pinRemoveMode(PinInfo *pin, uint32_t mask) {
 	if ((mask & PIN_GPIO) && (pin->enabled & PIN_GPIO)) {
 		gpio_deinit(data->gpio);
 		free(data->gpio);
+		// attach paths (re)initialize on a NULL pointer, not the enabled
+		// mask - a dangling pointer here means the next attach reuses the
+		// freed object instead of allocating a fresh one
+		data->gpio = NULL;
 		pinDisable(pin, PIN_GPIO);
 	}
 	if ((mask & PIN_IRQ) && (pin->enabled & PIN_IRQ)) {
 		data->irqHandler = NULL;
 		gpio_irq_free(data->irq);
 		free(data->irq);
+		data->irq = NULL;
 		pinDisable(pin, PIN_IRQ);
 	}
 	if ((mask & PIN_PWM) && (pin->enabled & PIN_PWM)) {
 		pwmout_free(data->pwm);
 		free(data->pwm);
+		data->pwm = NULL;
 		pinDisable(pin, PIN_PWM);
 	}
 }


### PR DESCRIPTION
Fixes #404.

`pinRemoveMode()` frees the per-pin pwm/gpio/irq driver objects but leaves the pointers dangling, and every attach path decides whether to (re)initialize by checking the pointer for NULL rather than the enabled mask — so the next attach after a remove reuses the freed object.

Three-line fix: null each pointer right after its `free()`.

Verified by compile for `bw15` (AmebaZ2) and `bw16` (AmebaD, via the family PR's bench setup); hardware regression coverage on RTL8720DN follows in the ongoing pin bring-up there.